### PR TITLE
MQ-93: added before/after_all error handling

### DIFF
--- a/spektrum/reporting/data.py
+++ b/spektrum/reporting/data.py
@@ -57,12 +57,12 @@ class CaseFormatData(object):
         return get_case_data(self._case).skip_reason
 
     @property
-    def before_each_traces(self):
-        return get_case_data(self._case).before_each_traces
+    def before_traces(self):
+        return get_case_data(self._case).before_traces
 
     @property
-    def after_each_traces(self):
-        return get_case_data(self._case).after_each_traces
+    def after_traces(self):
+        return get_case_data(self._case).after_traces
 
     @property
     def successful(self):
@@ -75,11 +75,11 @@ class CaseFormatData(object):
     def error_type(self):
         if getattr(self._spec.before_all, '__tracebacks__', []):
             return 'before_all'
-        elif self.before_each_traces:
+        elif self.before_traces:
             return 'before_each'
         elif getattr(self._spec.after_all, '__tracebacks__', []):
             return 'after_all'
-        elif self.after_each_traces:
+        elif self.after_traces:
             return 'after_each'
         else:
             return 'case'
@@ -119,9 +119,9 @@ class CaseFormatData(object):
         tracebacks = []
         tracebacks.extend(getattr(self._case, '__tracebacks__', []))
         tracebacks.extend(getattr(self._spec.before_all, '__tracebacks__', []))
-        tracebacks.extend(self.before_each_traces)
+        tracebacks.extend(self.before_traces)
         tracebacks.extend(getattr(self._spec.after_all, '__tracebacks__', []))
-        tracebacks.extend(self.after_each_traces)
+        tracebacks.extend(self.after_traces)
         return tracebacks
 
     @property

--- a/spektrum/spec.py
+++ b/spektrum/spec.py
@@ -37,6 +37,16 @@ class Spec(object):
 
         return parents[-1]
 
+    def _get_case(self, case_name):
+        return next(
+            case
+            for name, case in type(self).__members__().items()
+            if name == case_name
+        )
+
+    def _add_test_case(self, case):
+        self.__test_cases__.append(case)
+
     def __build_data_spec__(self):
         cases = []
         for test_func in self.__test_cases__:
@@ -155,8 +165,8 @@ class TestCaseData(object):
         self.data_kwargs = {}
         self.start_time = 0
         self.end_time = 0
-        self.before_each_traces = []
-        self.after_each_traces = []
+        self.before_traces = []
+        self.after_traces = []
 
 
 def incomplete(f):


### PR DESCRIPTION
Added before/after_all error reporting when using nested classes
```
F..F

After Failure Login
  ∟ ✗ after all

    Traceback occurred running after_all
    ----------------------------------------
    - /home/dmcdermitt/workspace/paladin/runners/spektrum/nexcess/api/login.py:44
    ----------------------------------------
    |          raise Exception
    |      class BeforeAllFailureTest(LoginFixture):
    |          pass
    |  
    |  
    |  class AfterFailureLogin(NexcessAPISpec):
    |      def after_all(self):
    ->         raise Exception
    ----------------------------------------
    - /home/dmcdermitt/workspace/paladin/runners/spektrum/nexcess/api/login.py:44
    ----------------------------------------
    |          raise Exception
    |      class BeforeAllFailureTest(LoginFixture):
    |          pass
    |  
    |  
    |  class AfterFailureLogin(NexcessAPISpec):
    |      def after_all(self):
    ->         raise Exception
    ----------------------------------------
    - Exception: 
    ----------------------------------------
  After All Failure Test
    ∟ ✓ can auth with username and password
      → ✓ resp.status_code to equal 200
      → ✓ body.get('authorization') to be an instance of str
      ↛ ✓ user_data_parent not to be None
      ↛ ✓ user_data not to be None
      → ✓ user_data.get('id') to be an instance of int
      → ✓ user_data.get('identity') to be an instance of str
      ↛ ✓ user_data not to be None
      → ✓ client_data.get('id') to be an instance of int
      → ✓ client_data.get('identity') to be an instance of str
Before Failure Login
  ∟ ✗ before all

    Traceback occurred running before_all
    ----------------------------------------
    - /home/dmcdermitt/workspace/paladin/runners/spektrum/nexcess/api/login.py:37
    ----------------------------------------
    |              require(user_data).not_to.be_none()
    |              expect(client_data.get('id')).to.be_an_instance_of(int)
    |              expect(client_data.get('identity')).to.be_an_instance_of(str)
    |  
    |  
    |  class BeforeFailureLogin(NexcessAPISpec):
    |      def before_all(self):
    ->         raise Exception
    ----------------------------------------
    - /home/dmcdermitt/workspace/paladin/runners/spektrum/nexcess/api/login.py:37
    ----------------------------------------
    |              require(user_data).not_to.be_none()
    |              expect(client_data.get('id')).to.be_an_instance_of(int)
    |              expect(client_data.get('identity')).to.be_an_instance_of(str)
    |  
    |  
    |  class BeforeFailureLogin(NexcessAPISpec):
    |      def before_all(self):
    ->         raise Exception
    ----------------------------------------
    - Exception: 
    ----------------------------------------
  Before All Failure Test
    ∟ ✓ can auth with username and password
Login
  ∟ ✓ can auth with username and password
    → ✓ resp.status_code to equal 200
    → ✓ body.get('authorization') to be an instance of str
    ↛ ✓ user_data_parent not to be None
    ↛ ✓ user_data not to be None
    → ✓ user_data.get('id') to be an instance of int
    → ✓ user_data.get('identity') to be an instance of str
    ↛ ✓ user_data not to be None
    → ✓ client_data.get('id') to be an instance of int
    → ✓ client_data.get('identity') to be an instance of str
------------------------
------- Summary --------
Pass            | 3
Skip            | 0
Fail            | 0
Error           | 2
Incomplete      | 0
Test Total      | 5
 - Expectations | 18
------------------------
```