### PR TITLE
MQ-597: fixed skipped reporting

### DIFF
--- a/spektrum/reporting/testrail.py
+++ b/spektrum/reporting/testrail.py
@@ -154,10 +154,10 @@ class TestRailRenderer(object):
         case_data.section_id = cached_data.section_id
 
         status = TestRailStatus.FAILED
-        if case_data.successful:
-            status = TestRailStatus.PASSED
-        elif case_data.skipped:
+        if case_data.skipped:
             status = TestRailStatus.SKIPPED
+        elif case_data.successful:
+            status = TestRailStatus.PASSED
 
         timespan = int(case_data.elapsed_time) or 1
 


### PR DESCRIPTION
https://madqe.testrail.io/index.php?/runs/view/26&group_by=cases:section_id&group_order=asc&group_id=1307

```
paladin -c ./cfg/des-ci-dev.yml -k $PALADIN_FERNET_KEY spektrum nexcess api --select-module login --tr-username software-qa@liquidweb.com --tr-apikey $TR_KEY --tr-project 6 --tr-suite 6 --tr-run 26
.FS

Login
  ∟ ✓ blarg
    → ✓ 1 to equal 1
  ∟ ✗ blargitty
    → ✗ 1 to equal 0
      Values:
      -------
      | 1: 1
  ∟ ☇ can auth with username and password - skipped: reason
------------------------
------- Summary --------
Pass            | 1
Skip            | 1
Fail            | 1
Error           | 0
Incomplete      | 0
Test Total      | 3
 - Expectations | 2
------------------------
```