### PR TITLE
V1.2.1 - updated require versions and travis python version

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.2.1
 commit = True
 tag = True
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,18 @@
 sudo: false
 language: python
-
+dist: lunar
 cache:
   directories:
   - "$HOME/.cache/pip"
-
 matrix:
   include:
-  - python: 3.8
+  - python: 3.12
     env: TOXENV=flake8
-
-  - python: 3.8
-    env: TOXENV=py38
-
+  - python: 3.12
+    env: TOXENV=py312
 install:
   - pip install pip tox codecov twine
-
-
-before_deploy: 'pip install urllib3==1.26.6'
-
+before_deploy: 'pip install urllib3==2.4.0'
 deploy:
   provider: pypi
   username: "__token__"
@@ -27,9 +21,7 @@ deploy:
   skip_existing: true
   on:
     tags: true
-
 script:
   - tox -e $TOXENV
-
 after_success:
   - codecov

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,8 +31,8 @@ copyright = u'2021, LiquidWeb'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = '1.2.0'
-release = '1.2.0'
+version = '1.2.1'
+release = '1.2.1'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 docopt
-pike>=0.0.2
+pike>=0.2.0
 pyevents
 httpx>=0.23.0
 python-dateutil>=2.8.2

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_desc = None
 if os.path.exists('README.rst'):
     long_desc = open('README.rst').read()
 
-version = '1.2.0'
+version = '1.2.1'
 
 setup(
     name='Spektrum',


### PR DESCRIPTION
* update version to ensure newer version of pike is pulled
* update travis ci to use python 3.12 instead of python 3.8