### PR TITLE
MQ-2499: Fixing TestRail reporting 

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.1
+current_version = 1.2.2
 commit = True
 tag = True
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,8 +31,8 @@ copyright = u'2021, LiquidWeb'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = '1.2.1'
-release = '1.2.1'
+version = '1.2.2'
+release = '1.2.2'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ long_desc = None
 if os.path.exists('README.rst'):
     long_desc = open('README.rst').read()
 
-version = '1.2.1'
+version = '1.2.2'
 
 setup(
     name='Spektrum',


### PR DESCRIPTION
* Ensures hierarchy of the test class when reporting back to TestRail when running sub modules
  * ex: submodule `test_testrail.TopClass.SubClass3`  will create a TestRail subject Hierarchy TopClass -> SubClass3 or Update the results in TopClass -> SubClass3
* DATASETs that are created during runtime in the `before_all` will now properly report in TestRail
* ensures all class and method names are spaced out to match test output in CLI
* moved testrail reporting and subject/case creation to be done after each test is run to ensure runtime created tests are captured and reported properly