### PR TITLE
MQ-3300: stop expect source lookup from crashing the reporter

### DIFF
--- a/spektrum/expect.py
+++ b/spektrum/expect.py
@@ -397,31 +397,54 @@ class ExpectParams(object):
 
     @property
     def cmp_call(self):
-        if self.expect_exp:
+        # `_get_closest_expression` falls back to the nearest expression statement
+        # whenever the calling line holds none of its own, so this can be any
+        # expression at all -- a bare `await`, a plain `helper()` call, a
+        # docstring. Only a call can be an `expect(X).to.matcher(Y)` chain, and
+        # everything below walks this node, so reject anything else up front.
+        if self.expect_exp and isinstance(self.expect_exp.value, ast.Call):
             return self.expect_exp.value
 
     @property
     def expect_call(self):
-        if self.cmp_call:
-            return self.cmp_call.func.value.value
+        # Verify the whole `expect(X).to.matcher(Y)` shape rather than trusting
+        # it. A bare `helper()` is a call whose func is a Name, and `self.a.b()`
+        # is a call whose func chain bottoms out somewhere other than a call.
+        cmp_call = self.cmp_call
+        if cmp_call is None or not isinstance(cmp_call.func, ast.Attribute):
+            return None
+
+        matcher_owner = cmp_call.func.value
+        if not isinstance(matcher_owner, ast.Attribute):
+            return None
+
+        expect_call = matcher_owner.value
+
+        return expect_call if isinstance(expect_call, ast.Call) else None
 
     @property
     def cmp_type(self):
-        if self.cmp_call:
-            return self.cmp_call.func.attr
+        cmp_call = self.cmp_call
+        if cmp_call is not None and isinstance(cmp_call.func, ast.Attribute):
+            return cmp_call.func.attr
 
     @property
     def cmp_arg(self):
         arg = None
-        if self.cmp_type in self.types_with_args:
+        # A matcher may still be written without its argument, so the argument
+        # list is not guaranteed to be populated just because the type matches.
+        if self.cmp_type in self.types_with_args and self.cmp_call.args:
             arg = decompile(self.cmp_call.args[0])
         return arg
 
     @property
     def expect_type(self):
-        return self.expect_call.func.id
+        expect_call = self.expect_call
+        if expect_call is not None and isinstance(expect_call.func, ast.Name):
+            return expect_call.func.id
 
     @property
     def expect_arg(self):
-        if self.expect_call:
-            return decompile(self.expect_call.args[0])
+        expect_call = self.expect_call
+        if expect_call is not None and expect_call.args:
+            return decompile(expect_call.args[0])

--- a/spektrum/reporting/data.py
+++ b/spektrum/reporting/data.py
@@ -169,13 +169,18 @@ class ExpectFormatData(object):
 
     @property
     def target_name(self):
-        if self._expect.src_params:
+        # The source expression is a best effort: it is absent whenever the
+        # statement behind the assertion was not an `expect(X).to.matcher(Y)`
+        # call. Fall back to the value rather than labelling it `None`, and test
+        # the resolved name rather than the params object, the way
+        # `Expectation.target_src_param` already does.
+        if self._expect.src_params and self._expect.src_params.expect_arg:
             return self._expect.src_params.expect_arg
         return str(self._expect.target)
 
     @property
     def expected_name(self):
-        if self._expect.src_params:
+        if self._expect.src_params and self._expect.src_params.cmp_arg:
             return self._expect.src_params.cmp_arg
         return str(self._expect.expected)
 

--- a/tests/test_expect_source.py
+++ b/tests/test_expect_source.py
@@ -1,0 +1,169 @@
+'''Regression coverage for the expect-source reporting defect.
+
+`get_expect_params` records the source expression behind every assertion so the
+reporter can print `foo to equal bar` rather than raw values. It locates that
+expression with `_get_closest_expression`, which falls back to the *nearest*
+expression statement whenever the calling line holds no expression statement of
+its own. An assignment is enough to trigger the fallback, because
+`outcome = expect(1).to.equal(2)` is an `ast.Assign`, not an `ast.Expr`.
+
+`ExpectParams` then assumes the statement it was handed is an
+`expect(X).to.matcher(Y)` call and walks `cmp_call.func.value.value` blindly. Any
+other statement shape raises. The reporter touches these properties only while
+rendering, so a run that has already finished every test loses its whole report:
+
+    pretty.py:146    f'{arrow} {mark} {expect.evaluation}'
+      -> expect.py    __str__ -> target_src_param -> expect_arg -> expect_call
+    AttributeError: 'Await' object has no attribute 'func'
+
+The `Await` node in that traceback is only the shape that happened to be caught.
+A bare `helper()` or `self.api.get()` next to an assertion poisons the same
+properties and is far more common in test code, so these checks sweep statement
+shapes rather than pinning the single reported one. Two further traps sit behind
+it:
+
+- Guarding `expect_call` alone is not enough. `__str__` also reads
+  `expected_src_param` -> `cmp_arg` -> `cmp_type`, which walks `cmp_call.func` by
+  a separate route.
+- The failure is not one exception type. An empty argument list reaches
+  `decompile(call.args[0])` and raises IndexError instead.
+
+These checks build `Expectation` objects directly rather than calling `expect()`,
+so a poisoned assertion is never registered with a live spec.
+'''
+import ast
+
+import pytest
+
+from spektrum.expect import (
+    Expectation,
+    ExpectParams,
+    _get_closest_expression,
+)
+from spektrum.reporting.data import ExpectFormatData
+
+
+# Ordinary lines of test code that may sit next to an assertion, and that
+# `_get_closest_expression` can therefore hand to `ExpectParams`.
+STATEMENT_SHAPES = [
+    ('bare-await', 'async def sample():\n    await helper()\n'),
+    ('awaited-chain', 'async def sample():\n    await self.api.get()\n'),
+    ('bare-call', 'def sample():\n    helper()\n'),
+    ('method-call', 'def sample():\n    self.helper()\n'),
+    ('chained-call', 'def sample():\n    self.api.get()\n'),
+    ('deep-chained-call', 'def sample():\n    self.a.b.c()\n'),
+    ('subscript-call', 'def sample():\n    items[0]()\n'),
+    ('lambda-call', 'def sample():\n    (lambda: 1)()\n'),
+    ('call-of-call', 'def sample():\n    factory()()\n'),
+    ('docstring', 'def sample():\n    "a docstring"\n'),
+    ('bare-name', 'def sample():\n    value\n'),
+    ('bare-attribute', 'def sample():\n    self.value\n'),
+    ('f-string', 'def sample():\n    f"{value}"\n'),
+    ('comparison', 'def sample():\n    left == right\n'),
+    ('boolean-op', 'def sample():\n    left and right\n'),
+    ('unary-op', 'def sample():\n    not value\n'),
+    ('ternary', 'def sample():\n    a if b else c\n'),
+    ('list-literal', 'def sample():\n    [1, 2]\n'),
+    ('dict-literal', 'def sample():\n    {1: 2}\n'),
+    ('list-comprehension', 'def sample():\n    [each for each in items]\n'),
+    ('generator', 'def sample():\n    (each for each in items)\n'),
+    ('slice', 'def sample():\n    items[1:2]\n'),
+    ('yield', 'def sample():\n    yield value\n'),
+    ('ellipsis', 'def sample():\n    ...\n'),
+    ('awaited-expect', 'async def sample():\n    await expect(v).to.equal(1)\n'),
+    ('single-attribute-matcher', 'def sample():\n    expect(v).to_be_thing()\n'),
+    ('expect-without-arguments', 'def sample():\n    expect().to.equal(2)\n'),
+    ('matcher-without-arguments', 'def sample():\n    expect(v).to.equal()\n'),
+]
+
+SOURCE_PROPERTIES = [
+    'expect_call',
+    'cmp_type',
+    'cmp_arg',
+    'expect_arg',
+]
+
+# Real assertions must keep rendering their own source text. Without these a fix
+# that simply returned None everywhere would satisfy the sweep above while
+# silently reducing every report to bare values.
+RENDERED_ASSERTIONS = [
+    ('expect(value).to.equal(2)', 'value to equal 2'),
+    (
+        'expect(php[\'account_version\']).to.equal(self.versions[0])',
+        'php[\'account_version\'] to equal self.versions[0]',
+    ),
+    (
+        'expect(service.package.id).to.equal(upgrade_package.id)',
+        'service.package.id to equal upgrade_package.id',
+    ),
+]
+
+ASSIGNED_EXPECT_SOURCE = '''
+async def sample():
+    await helper()
+    outcome = expect(1).to.equal(2)
+    return outcome
+'''
+
+# The `outcome = ...` line above. It is an assignment, so no expression statement
+# shares its line and `_get_closest_expression` falls back to the bare `await`.
+ASSIGNED_EXPECT_LINE = 4
+
+SHAPE_IDS = [label for label, _ in STATEMENT_SHAPES]
+SHAPE_SOURCES = [source for _, source in STATEMENT_SHAPES]
+
+
+def statement_for(source):
+    '''The first statement inside the sample function in this source.'''
+    return ast.parse(source).body[0].body[0]
+
+
+@pytest.mark.parametrize('prop', SOURCE_PROPERTIES)
+@pytest.mark.parametrize('source', SHAPE_SOURCES, ids=SHAPE_IDS)
+def test_source_property_resolves_for_any_statement(source, prop):
+    '''No statement shape may make a source property raise.'''
+    getattr(ExpectParams(statement_for(source)), prop)
+
+
+@pytest.mark.parametrize('source', SHAPE_SOURCES, ids=SHAPE_IDS)
+def test_rendering_succeeds_for_any_statement(source):
+    '''The reporter renders every assertion through `str()`; it must not raise.'''
+    str(Expectation(1, src_params=ExpectParams(statement_for(source))))
+
+
+def test_expression_chosen_for_an_assigned_expect_is_usable():
+    '''The real selection path must not hand back an unusable statement.'''
+    chosen = _get_closest_expression(
+        ASSIGNED_EXPECT_LINE,
+        ast.parse(ASSIGNED_EXPECT_SOURCE),
+    )
+
+    for prop in SOURCE_PROPERTIES:
+        getattr(ExpectParams(chosen), prop)
+
+
+@pytest.mark.parametrize('source, wanted', RENDERED_ASSERTIONS)
+def test_real_assertions_keep_rendering_their_source(source, wanted):
+    '''A guard against a fix that resolves the crash by resolving nothing.'''
+    expectation = Expectation('actual', src_params=ExpectParams(ast.parse(source).body[0]))
+    expectation.to.equal('actual')
+
+    assert str(expectation) == wanted
+
+
+@pytest.mark.parametrize('source', SHAPE_SOURCES, ids=SHAPE_IDS)
+def test_reporter_labels_fall_back_to_the_value(source):
+    '''An unresolved source expression must not be reported as the name `None`.
+
+    The reporter prints `f'| {expect.target_name}: {expect.target}'`, so a
+    `target_name` of None renders the label `None:` next to the value.
+
+    Shapes that really are `expect(X).to.matcher(Y)` calls still resolve their
+    own source text, so this asserts only that a label is always produced.
+    '''
+    expectation = Expectation('the-target', src_params=ExpectParams(statement_for(source)))
+    expectation.to.equal('the-expected')
+    reported = ExpectFormatData(expectation)
+
+    assert reported.target_name is not None
+    assert reported.expected_name is not None


### PR DESCRIPTION
## Problem

A run can complete **every test successfully** and then lose its entire report at render time. The tests pass, the process dies, no results survive.

Observed in a large downstream suite, after every test had already executed:

```
pretty.py:146    f'{arrow} {mark} {expect.evaluation}'
  -> data.py:152     str(self._expect)
  -> expect.py:72    __str__ -> target_src_param
  -> expect.py:426   expect_arg -> expect_call
  -> expect.py:406   return self.cmp_call.func.value.value
AttributeError: 'Await' object has no attribute 'func'
```

## Root cause

`get_expect_params()` records the source expression behind each assertion so the reporter can print `foo to equal bar`. It locates that expression with `_get_closest_expression()`, which falls back to the **nearest expression statement by line distance** whenever the calling line holds no expression statement of its own.

An assignment is enough to trigger the fallback — `outcome = expect(1).to.equal(2)` is an `ast.Assign`, not an `ast.Expr`. `ExpectParams` then assumed it had an `expect(X).to.matcher(Y)` call and walked `cmp_call.func.value.value` blindly.

## The blast radius is wider than that traceback

The `Await` node was only the shape that happened to get caught. Sweeping expression forms against the unfixed code gives **235 failures across 52 expressions**, and three things fall out:

- A bare `helper()`, `self.helper()` or `self.api.get()` next to an assertion poisons the same properties — and bare calls are far more common in test code than a bare `await`.
- **Guarding `expect_call` alone is insufficient.** `__str__` also reaches `expected_src_param` → `cmp_arg` → `cmp_type`, which walks `cmp_call.func` by a separate route.
- **It is not one exception type.** A matcher written without its argument reaches `decompile(args[0])` on an empty list and raises `IndexError`.

Two things raise the severity beyond a cosmetic reporting bug:

- `--show-all-expects` is passed unconditionally by some consumers, so the per-assertion rendering path is always live and the crash cannot be avoided from the CLI.
- `TestRailRenderer` reaches the same properties **per-case during a run**, not at the end, so results already collected can be lost mid-flight.

## Change

- `cmp_call` — reject anything that is not an `ast.Call` up front.
- `expect_call` — verify the whole `expect(X).to.matcher(Y)` chain instead of trusting it.
- `cmp_type` — only read `.attr` off an `ast.Attribute`.
- `cmp_arg` / `expect_arg` — bounds-check the argument lists.
- `expect_type` — guarded the same way for consistency (currently unused).
- `ExpectFormatData.target_name` / `expected_name` — fall back to the value when the source expression cannot be resolved, testing the resolved name rather than the params object, the way `Expectation.target_src_param` already did. Without this the reporter prints the label `None:` beside the value.

## Testing

`tests/test_expect_source.py` sweeps 28 statement shapes across the source properties and the `str()` render path, exercises the real `_get_closest_expression` selection path, and adds a control asserting real assertions keep rendering their own source text — so the suite cannot be satisfied by a fix that resolves nothing.

Same test file, source changes stashed vs applied:

```
without the fix:  153 failed, 19 passed
with the fix:     175 passed          (full suite, includes the 3 pre-existing tests)
```

flake8 clean under this repo's config.

End-to-end through the runner and reporter — an assignment-style expect beside a bare `await`, the exact shape that crashed:

```
Crash Repro
  ∟ ✗ can assign expect next to a bare await
    → ✗ 1 to equal 2
      Values:
      -------
      | 1: 1
------- Summary --------
Pass 0 | Fail 1 | Error 0
```

Previously this aborted the process and destroyed the report; it now renders a complete one.

## Scope

This fixes the **reporting crash**, not the **misattribution**. `_get_closest_expression` still selects the wrong statement; such an assertion now renders raw values instead of source text — degraded rather than fatal. Improving that heuristic is separate follow-up work.

## Version

Bumped **1.3.0 → 1.3.1 (patch)**. No API surface is added or changed — the fix guards
existing properties and adds a fallback. This matches the precedent of `1.2.1 → 1.2.2`,
which was also a reporting bug fix, where `1.2.2 → 1.3.0` was reserved for a new feature.

Version strings were updated the way `bumpversion` would (`setup.py`, `docs/conf.py`
`version` and `release`, `.bumpversion.cfg`) but applied by hand, so **no release tag is
created from this branch** — the config sets `commit = True` and `tag = True`, and tagging
is the maintainer's release step rather than part of this PR.

`docs/release_notes/index.rst` has an entry again. Worth flagging: it had not been updated
since **1.0.0**, so 1.1.x through 1.3.0 shipped with no notes and the file now jumps from
1.3.1 straight to 1.0.0. Backfilling that gap is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Version bump removed

This PR no longer carries the `1.3.0 → 1.3.1` bump or the `Release: 1.3.1` note it
originally included. Per [docs/maintenance/index.rst](../blob/master/docs/maintenance/index.rst),
the version is bumped on a dedicated `prep_for_release` branch that writes the notes for
everything merged since the last release — not in the fix PRs themselves.

The reason it matters here: #17 is a second, independent fix awaiting review. With a bump
in this PR, whichever of the two merges second would be absent from the release its own
version number claims to be, and `master` would sit at 1.3.1 containing an undocumented
change. Both fixes now merge in any order, and one release PR afterwards covers them
together.

The release-note prose written here is preserved and will be carried into that release PR
verbatim, with a bullet added for #17.

## Verification (re-run after the strip)

- Red-then-green, source files reverted to `master` with the tests kept:
  **RED 153 failed / 20 passed → GREEN 173 passed**
- `python -m spektrum -s tests/live/` — 22 passed, 121 expectations
- `python -m flake8 spektrum tests` — exit 0

The total is 173 rather than the 175 seen earlier: the two `tests/reporting/` tests that
were briefly on this branch belong to #17 and have moved there.
