### PR TITLE
MQ-3301: add agent docs and spec-driven development setup

### DIFF
--- a/.claude/conventions.md
+++ b/.claude/conventions.md
@@ -1,0 +1,84 @@
+# Coding Conventions — Spektrum
+
+Python standards for this repo. There is no automated checker wired up here, so these
+apply by review and by judgement.
+
+**Spektrum is older than several of these rules.** Existing code violates some of them —
+`except Exception:` in `Expectation.raise_a`, mixed quote delimiters, missing type hints.
+That is deliberate and is **not** a backlog to burn down inside an unrelated change. Apply
+these to code you add or modify; leave the rest alone. See "Scope discipline" in
+[openspec/project.md](../openspec/project.md).
+
+## Mechanical
+
+Lint with `tox -e flake8`. Max line length **100**. `H301,H405,H702,W503` ignored;
+`spektrum/vendor/*` excluded and never reformatted.
+
+- **Quotes** — single quotes as the delimiter, `'''` for docstrings. Only the *outer*
+  delimiter matters; an inner `"` is fine.
+- **Trailing commas** — required on every multi-line construct: parenthesised imports,
+  dict/list/tuple literals. Single-line collections do not need one.
+- **Exceptions** — no bare `except:`, no base `except Exception:`. Catch specific types.
+  Catch *every* type the guarded call can raise: an AST walk that raises `AttributeError`
+  on one shape may raise `IndexError` on another.
+- **No `print()` for diagnostics** — use `spektrum.logger`. Reporters under `reporting/`
+  are the exception: writing to stdout is what they are for.
+- **`await` only inside `async def`.**
+- **Naming** — PascalCase classes, snake_case functions and variables. Dunders and
+  ALL_CAPS constants exempt. No `Common` in a class name.
+- **Pythonic** — `is None` not `== None`; truthiness not `len(x) == 0`; direct iteration
+  not `range(len(...))`.
+- **Imports** — a multi-item `from x import a, b` uses the parenthesised multi-line form
+  with a trailing comma.
+- **Every package folder needs `__init__.py`** (may be empty).
+
+## Type hints
+
+Newer modules (`runner.py`, parts of `reporting/`) are annotated; older ones are not.
+Annotate what you add.
+
+- Parameters get annotations; a function returning non-None annotates its return.
+  `-> None` is never required.
+- `Optional[T]`, `List[T]`, `Dict[K, V]` — not bare `list` / `dict`, not `Union[T, None]`.
+- `**kwargs` may be left untyped.
+
+## Design
+
+- **KISS** — no indirection that earns nothing: alias-only properties, a variable assigned
+  only to be returned, a wrapper used once.
+- **YAGNI** — no speculative parameters or abstractions for a single implementation.
+- **SRP** — one responsibility per unit.
+- **Composition over inheritance** — do not subclass merely to borrow a method.
+- **DRY** — lift genuinely duplicated logic; do not over-abstract two lines that merely
+  look alike.
+
+## Library-specific rules
+
+These matter more here than they would in an application.
+
+- **Guard defensively at the boundary, then trust inward.** `expect.py` reads AST nodes
+  produced by arbitrary user source. Validate the shape you require before walking it,
+  rather than walking it and catching the fallout.
+- **A reporter must never be able to kill a run.** Everything under `reporting/` executes
+  after — or, for TestRail and the live view, *during* — tests that have already produced
+  results. An exception there destroys work that was already complete and unrecoverable.
+  Rendering code should degrade to a less informative line, never raise.
+- **Do not change what a public property returns without checking its consumers.**
+  Returning `None` where a caller expects a string relocates a crash rather than fixing
+  it; give the caller a sensible fallback in the same change.
+- **Every behavioural change needs a red-then-green test.** See
+  [openspec/project.md](../openspec/project.md).
+
+## Test conventions
+
+`tests/` holds two suites: `tests/test_runner.py` is pytest, and `tests/live/` is
+Spektrum specs run by the CLI. Neither runner sees the other's tests — see
+[AGENTS.md](../AGENTS.md). New unit-level work goes in the pytest suite.
+
+- `pytest.mark.parametrize` with explicit `ids` for shape sweeps; a failing id should name
+  the case without opening the file.
+- Prefer constructing units directly (`ExpectParams`, `Expectation`, `ExpectFormatData`)
+  over driving the whole runner, so a failure localises.
+- A "does not raise" test needs no assertion body — the call raising *is* the failure.
+- When a fix could be satisfied by returning nothing, add a control test asserting the
+  healthy path still produces real output.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+**Issue:** <!-- Link the issue this addresses, or say why there isn't one. -->
+
+## Why
+
+<!-- What problem does this solve? One sentence is enough if the issue has the detail. -->
+
+## What
+
+<!-- What changed? Bullet points of the approach taken. -->
+
+### Blast radius
+
+<!-- Spektrum is a library: which consumers see this? e.g. reporters only / the runner /
+the public API in spektrum/__init__.py / a CLI flag's behaviour. -->
+
+## Reading guide
+
+<!-- Optional for a small change. For anything touching more than one file, map it for
+reviewers before they read the diff. -->
+
+| File | What to look at | Why |
+|---|---|---|
+| `` | … | … |
+
+## Test plan
+
+**Red-then-green** (required for a behavioural change — see
+[openspec/project.md](../openspec/project.md)):
+
+- Failing without the change: <!-- paste the count -->
+- Passing with the change: <!-- paste the count -->
+
+**Automated tests added/updated:**
+- [ ] …
+
+**Manual verification steps:**
+1. …
+
+## Checklist
+
+- [ ] `python -m pytest tests -q` — paste the count
+- [ ] `python -m spektrum -s tests/live/` — paste the count (pytest does not collect
+      these, and under `python -m` a nonexistent search path exits 0, so the count is the
+      only proof the suite ran)
+- [ ] `tox -e flake8` clean
+- [ ] Docs updated (`README.rst` / `AGENTS.md` / `docs/`) if this changes how the project
+      is built, run, or used
+- [ ] Squashed to a single commit (see
+      [openspec/project.md](../openspec/project.md) — Before opening a PR, step 5)
+- [ ] No version bump unless this PR is the release
+- [ ] No secrets, tokens, or real customer data included

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,191 @@
+# Spektrum
+
+An async Python test framework: spec classes, fluent assertions, and pluggable reporters,
+driven by the `spektrum` CLI.
+
+This file is the entry point for any agent working in the repo. `CLAUDE.md` is a symlink
+to it.
+
+## MANDATORY — read before changing anything
+
+- **Any change** → [openspec/project.md](openspec/project.md) — the PR procedure, the
+  red-then-green rule, one-commit-per-PR, scope discipline, and the reporter
+  compatibility contract.
+- **Any Python change** → [.claude/conventions.md](.claude/conventions.md).
+
+Spektrum is a library. A defect does not fail one test; it changes what every suite built
+on it reports, and every consumer picks it up at once. Treat the blast radius as the
+default assumption, not the exception.
+
+## Architecture in a paragraph
+
+`spektrum.__main__` parses arguments and hands a search path to `SpektrumRunner`
+(`runner.py`), which uses `pike` to discover `Spec` subclasses under that path. Specs form
+a tree — a spec's nested `Spec` subclasses become child specs — and the runner walks it
+asynchronously, running the lifecycle hooks around each case with concurrency bounded by
+semaphores. Each `expect()` / `require()` call builds an `Expectation` (`expect.py`),
+registers it against the running spec, and records the **source expression** behind it by
+inspecting the caller's frame and AST, so the reporter can print `value to equal 2` rather
+than `1 to equal 2`. When the run finishes, the runner builds a report of
+`SpecFormatData` / `CaseFormatData` / `ExpectFormatData` wrappers (`reporting/data.py`)
+and hands that list to the console renderer, plus the xunit renderer when
+`--xunit-results` is set. Two reporters never see it: TestRail is
+driven per-case *during* the run, and the live view is fed from an event queue from before
+discovery starts.
+
+## What counts as a case
+
+Not derivable at a glance, and easy to get wrong:
+
+- Every **public instance method** that is not a lifecycle hook (`before_all`,
+  `before_each`, `after_each`, `after_all`) is a case. There is no naming prefix to opt
+  in, and no decorator to opt out — `@skip`, `@incomplete` and `@metadata` all leave the
+  method a case.
+- `_`-prefixed methods are skipped, as is anything that isn't a plain function on the
+  class: `@classmethod`, `@staticmethod` and `@property` members are never cases.
+- A `DATASET` on the class replaces each case with one per dataset key, so the original
+  case name never runs.
+- Nested `Spec` subclasses become child specs; `@fixture`-decorated ones are skipped.
+
+## File map
+
+```
+.
+├── spektrum/
+│   ├── __init__.py        # public surface: Spec, DataSpec, expect, require, fixture,
+│   │                      #   skip, skip_if, incomplete, metadata, depends_on, concurrency
+│   ├── __main__.py        # the CLI (console_scripts: spektrum)
+│   ├── runner.py          # SpektrumRunner + the async spec/case execution tree
+│   ├── spec.py            # Spec, DataSpec, the decorators, case/spec filtering
+│   ├── expect.py          # Expectation/Requirement, the matchers, and the AST-based
+│   │                      #   source-expression lookup (ExpectParams)
+│   ├── reporting/
+│   │   ├── core.py        # ReportManager — fans out to the enabled reporters
+│   │   ├── data.py        # the *FormatData wrappers every reporter renders from
+│   │   ├── pretty.py      # default console output
+│   │   ├── testrail.py    # TestRail — reached PER-CASE DURING a run
+│   │   ├── xunit.py       # xunit XML for CI
+│   │   ├── live.py        # LiveServer: the --live HTTP server, its SSE stream, and the
+│   │   │                  #   page it serves
+│   │   └── transport.py   # RetryTransport — an httpx transport with retries, used for
+│   │                      #   outbound reporter HTTP, NOT part of the live view
+│   ├── exceptions.py, logger.py, utils.py
+│   └── vendor/            # vendored ast_decompiler — never reformat, excluded from lint
+├── tests/
+│   ├── test_runner.py     # pytest: drives SpektrumRunner over tests/example_data
+│   ├── example_data/      # sample Spec classes used as runner fixtures
+│   └── live/              # Spektrum specs, run by the CLI — see "Two suites" below
+├── docs/                  # Sphinx source for the published user documentation
+│   ├── index.rst          # toctree root
+│   ├── using/, writing_tests/, parallel/, reporting/, release_notes/, maintenance/
+│   └── conf.py            # carries the version too — .bumpversion.cfg updates both
+├── openspec/              # spec-driven-development artifacts
+│   ├── project.md         # the rules — read this first
+│   ├── config.yaml        # schema: spec-driven
+│   ├── specs/             # capability baseline (the six live-view capabilities)
+│   └── changes/           # in-flight proposals, plus archive/ of completed ones
+├── tools/run_tests.sh     # stale — calls nosetests; use the commands below instead
+├── .claude/conventions.md # Python standards
+├── tox.ini                # pytest+coverage envs, the flake8 env, and the flake8 config
+└── setup.py               # version lives here and in .bumpversion.cfg
+```
+
+## Two suites, and neither runs the other
+
+`tests/` holds two suites with different runners. Running one and calling it green is the
+most common way to break this repo.
+
+| Suite | Runner | What it covers |
+|---|---|---|
+| `tests/test_runner.py` | **pytest** | unit-level: constructs runner/report objects directly |
+| `tests/live/` | **the `spektrum` CLI** | the live view end-to-end, as `Spec` classes |
+
+`pytest tests` does not collect `tests/live/` at all — those are `Spec` subclasses, and
+pytest has no idea what to do with them. Run both:
+
+```shell
+python -m pytest tests -q          # the pytest suite
+python -m spektrum -s tests/live/  # the spec suite
+```
+
+The split is deliberate. Unit-level work belongs in pytest, because the framework cannot
+be its own harness when the code under test is what renders the result — a bug in
+reporting would corrupt the report that tells you about the bug. The live view is the
+exception: what it emits *is* observable only from a real run, so those tests drive the
+real CLI and assert on what a real run produces. `tests/example_data/` holds spec classes
+too, but those are *fixtures the runner executes*, not assertions.
+
+Test the units directly. `ExpectParams`, `Expectation` and the `*FormatData` wrappers can
+all be constructed by hand. Note `Expectation(...)` built directly does **not** register
+with a spec — `_add_expect_to_spec()` is called only by the `expect()` and `require()`
+factories — which is what lets a test exercise a pathological assertion without poisoning
+the live report.
+
+## Commands
+
+```shell
+pip install -r dev-requirements.txt
+
+python -m pytest tests -q            # pytest suite
+python -m spektrum -s tests/live/    # spec suite (see above — pytest skips these)
+tox -e flake8                        # lint (max line length 100)
+
+spektrum -s <path>                   # run specs at a path
+spektrum -s <path> --show-all-expects   # + one line per assertion
+```
+
+Useful CLI flags: `-p/--select-module`, `-t/--select-tests`, `-m/--select-by-metadata` /
+`--exclude-by-metadata`, `-c/--concurrency`, `--dry-run`, `--coverage`,
+`--xunit-results`, `--live` / `--live-port` / `--live-linger`, and the `--tr-*` TestRail
+options.
+
+`tox`'s `envlist` is `py{36,37,38,39},pypy3,flake8` — stale, so a bare `tox` fails on
+every interpreter that isn't installed and reports red even though `flake8` passed. CI
+runs `tox -e py312` and `tox -e flake8` (`.travis.yml`); use those, or call `pytest`
+directly. `tox -e py312` works despite py312 being absent from `envlist`.
+
+> `--show-all-expects` matters more than it looks. Consumers that wrap the CLI may enable
+> it unconditionally, so the per-assertion rendering path can be live on every run for
+> those users. A defect reachable only under that flag is not an edge case downstream.
+
+## Specs
+
+`openspec/specs/` is the capability baseline — currently the six capabilities behind the
+live view (`--live`), all of them released. Behaviour described there is a contract that
+shipped, so read the relevant spec before changing `reporting/live.py`, `transport.py`, or
+the runner's live-event emission. Completed proposals live in
+`openspec/changes/archive/`; anything in flight sits directly under `openspec/changes/`.
+
+```shell
+openspec list                # in-flight changes and their task progress
+openspec validate --all      # every spec and change
+```
+
+## Known sharp edges
+
+- A nested class that is **not** a `Spec` subclass crashes discovery:
+  `spec_filter` in `spec.py` reads `is_fixture` off the class before checking
+  `issubclass(other, Spec)`, so a plain helper class inside a spec raises
+  `AttributeError`. Put helpers at module level.
+- `python -m spektrum` exits 0 on a nonexistent search path — `__main__` discards
+  `main()`'s return value, while the `spektrum` console script (`sys.exit(main())`) exits
+  1. A failing case exits 1 either way. Check the reported count, not just the exit code.
+
+## Versions and releasing
+
+The repo disagrees with itself about supported Python: `setup.py` says
+`python_requires='>=3.5'` with a lone 3.7 classifier, `tox.ini`'s `envlist` says
+py36–py39 + pypy3, and CI tests only 3.12. Treat **3.12 as the supported version** — it is
+the only one actually exercised — and don't take the other two as constraints without
+asking.
+
+Releasing is `bumpversion`, which updates `setup.py` and `docs/conf.py` together, commits,
+and tags. The tag is what publishes to PyPI from CI, so a version bump in an ordinary PR
+ships a release by accident.
+
+## See also
+
+- [README.rst](README.rst) — user-facing intro.
+- [docs/](docs/) — Sphinx source for the published documentation.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to get a change reviewed.
+- [openspec/project.md](openspec/project.md) — PR procedure and compatibility contract.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Spektrum is a Python testing framework inspired by RSpec and Jasmine. Contributions are
+welcome — this file covers how to get one reviewed.
+
+## Development setup
+
+```shell
+pip install -r dev-requirements.txt
+```
+
+Build, test and lint commands are listed in [AGENTS.md](AGENTS.md#commands) and not
+repeated here.
+
+## Spektrum is a library
+
+A defect here does not fail one test. It changes what every suite built on Spektrum
+reports, and every consumer picks it up at once. [openspec/project.md](openspec/project.md)
+is the full working agreement — the red-then-green rule, scope discipline, and the
+reporter compatibility contract. Read it before opening a PR.
+
+The short version:
+
+- **Prove the change.** A behavioural change needs a test that fails without it and passes
+  with it. Put both counts in the PR.
+- **Run both suites.** `tests/` has a pytest suite *and* a suite of Spektrum specs that
+  pytest does not collect. See [AGENTS.md](AGENTS.md#two-suites-and-neither-runs-the-other).
+- **Keep the diff to the change.** Pre-existing problems in a file you touched are worth
+  reporting, not worth widening the diff for. Don't reformat existing code.
+
+## Opening a PR
+
+Use the PR template — link the issue it addresses and describe how you verified the change.
+Base branch is `master`.
+
+## Before you open a PR
+
+- [ ] `python -m pytest tests -q` passes — record the count
+- [ ] `python -m spektrum -s tests/live/` passes — record the count. A failing case does
+      exit 1, but a **nonexistent search path** exits 0 under `python -m` (the `spektrum`
+      console script exits 1 there), so a typo'd path looks like success
+- [ ] `tox -e flake8` is clean (max line length 100)
+- [ ] A test proves the change: observed failing before, passing after
+- [ ] Docs (`README.rst`, `AGENTS.md`, `docs/`) updated if this changes how the project is
+      built, run, or used
+- [ ] Squashed to a single commit, with the evidence above folded into the message body.
+      Work in as many commits as you like locally; a PR is one commit

--- a/README.rst
+++ b/README.rst
@@ -16,10 +16,91 @@ Spektrum is open-source and is available on `GitHub`_. We love contributions!
 Getting Started
 ~~~~~~~~~~~~~~~~
 
+Install from PyPI::
+
+    pip install spektrum
+
+Tests are plain classes. A ``Spec`` subclass groups cases: every public method that is
+not a lifecycle hook (``before_all``, ``before_each``, ``after_each``, ``after_all``) and
+not underscore-prefixed is a case. Nested Spec subclasses become child specs::
+
+    from spektrum import Spec, expect
+
+    class Addition(Spec):
+        def before_each(self):
+            self.total = 1 + 1
+
+        def sums_two_numbers(self):
+            expect(self.total).to.equal(2)
+
+Run them by pointing the CLI at a path::
+
+    spektrum -s path/to/specs
+
+Spektrum looks for a ``spec`` directory in the working directory when ``-s`` is omitted.
+Add ``--show-all-expects`` to print a line per assertion rather than per case, and
+``-c N`` to run with concurrency.
+
+Selecting what runs
+~~~~~~~~~~~~~~~~~~~~
+
+While you iterate on one spec, narrow the run rather than sitting through the whole suite.
+
+``-p`` selects by module path -- either a bare module or a class inside it::
+
+    spektrum -s spec -p checkout                 # every spec in checkout.py
+    spektrum -s spec -p checkout.PaymentFlow     # one class and its children
+
+Prefix the value with ``re:`` to match class paths by regular expression. The pattern is
+anchored at the end, so it must describe the *tail* of the path -- a pattern that merely
+appears in the middle matches nothing, with no error to tell you so::
+
+    spektrum -s spec -p "re:checkout\..*Payment"     # classes ending in Payment
+    spektrum -s spec -p "re:checkout\..*Payment.*"   # and those only containing it
+
+``-t`` selects by case name, as a comma-delimited list. A name matches in every spec that
+defines it, so one name can run in several places::
+
+    spektrum -s spec -t adds_item_to_cart
+    spektrum -s spec -t adds_item_to_cart,removes_item_from_cart
+
+``-t`` accepts ``re:`` as well. That pattern is anchored at *both* ends, and is tried
+against the method name and against the spaced form Spektrum prints in its output::
+
+    spektrum -s spec -t "re:adds item to cart"
+
+``-m`` selects by the ``@metadata`` decorator and ``--exclude-by-metadata`` is its
+complement, which is how you mark a slow or environment-dependent group and skip it while
+working locally::
+
+    spektrum -s spec -m suite=smoke
+    spektrum -s spec --exclude-by-metadata suite=slow
+
+``--dry-run`` reports the tree without executing anything or evaluating a single assertion
+-- the quickest way to confirm a filter selects what you meant before you wait on a run.
+
 Continuous Integration
 ~~~~~~~~~~~~~~~~~~~~~~~
+
+Spektrum writes xunit XML for CI systems that consume it::
+
+    spektrum -s path/to/specs --xunit-results results.xml
+
+``--coverage`` records coverage data for the code under test into ``.coverage``, for a
+following ``coverage report``; it prints nothing itself. ``--live`` serves a live progress
+view over HTTP while the run is in flight. Spektrum ships console, xunit, live and TestRail
+reporters, the last through the ``--tr-*`` options.
+
+Contributing
+~~~~~~~~~~~~~~
+
+See the `contributing guide
+<https://github.com/liquidweb/spektrum/blob/master/CONTRIBUTING.md>`_ for setup, the test
+suites, and what a change needs to prove before review.
 
 Release Notes
 ~~~~~~~~~~~~~~
 
-- `Release notes`_ are available in the documentation
+- `Release notes
+  <https://github.com/liquidweb/spektrum/blob/master/docs/release_notes/index.rst>`__ are
+  available in the documentation

--- a/openspec/changes/add-agent-docs/.openspec.yaml
+++ b/openspec/changes/add-agent-docs/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-25
+skip_specs: true

--- a/openspec/changes/add-agent-docs/design.md
+++ b/openspec/changes/add-agent-docs/design.md
@@ -1,0 +1,105 @@
+## Context
+
+See proposal.md — Why.
+
+The constraints that shape the approach:
+
+- **The repository is public.** Any rule borrowed from a downstream project has to be
+  generalised. Much of what such a project enforces — provisioning, result-tracking
+  cycles, its own CLI wrapper, ticket workflow — is specific to its environment and both
+  meaningless and inappropriate here.
+- **Spektrum predates several of the conventions worth writing down.** `raise_a` catches
+  base `Exception`, quote delimiters are mixed, older modules carry no type hints. Any
+  standards document has to say what it applies to, or it reads as authorisation to
+  reformat the tree.
+- **`openspec/` already contains empty `specs/` and `changes/` directories.** Git cannot
+  store an empty directory, so these exist only in working copies. Nothing in them is
+  tracked, and nothing depends on them.
+- **`tests/` is pytest, while the project itself is a spec framework.** This surprises
+  every reader and needs explaining rather than restating.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- An agent or new contributor can find the layout, the commands, and the review bar from
+  the repository root without asking.
+- The library risk profile is stated explicitly, including which modules are on the path
+  that renders downstream output.
+- OpenSpec tooling actually runs against this repo.
+- Documents remain true for a reader with no connection to any particular downstream
+  consumer.
+
+**Non-Goals:**
+
+- Fixing the pre-existing convention violations the standards document names. Recording a
+  rule and retrofitting it are separate pieces of work; bundling them makes the diff
+  unreviewable.
+- Backfilling `docs/release_notes/index.rst`, which has had no entry since 1.0.0.
+- Writing capability specs. This change adds no runtime behaviour.
+- Documenting any specific downstream consumer's workflow.
+
+## Decisions
+
+**One `AGENTS.md` at the root, with `CLAUDE.md` as a symlink.** A single file avoids the
+two-file drift where one copy is updated and the other rots. The symlink means
+tool-specific filename expectations resolve to the same content. Alternative considered: a
+`CLAUDE.md` that merely points at `AGENTS.md` — rejected, since a reader following the
+pointer pays two hops for nothing.
+
+**Split the rules by lifetime.** `openspec/project.md` holds the process that governs a
+change (how to prove it, what blocks a PR, scope discipline); `.claude/conventions.md`
+holds the Python standards; `AGENTS.md` holds the map. Process, style, and orientation
+change on different cadences, and one combined document guarantees the stale parts drag
+down trust in the fresh parts.
+
+**Scope the conventions document to new and modified code, in its own text.** Stating this
+inside the document is what stops it from being read as a reformatting mandate. Rejected
+alternative: fixing the violations first so the document can be unconditional — that is a
+much larger, riskier change and would have to be justified on its own merits.
+
+**Generalise rather than copy.** Where a downstream project's rule encodes a real
+engineering constraint (prove a fix with a failing test first; do not widen a diff; do not
+reformat vendored code), keep the constraint and drop the environment. Where the rule is
+purely about that project's infrastructure, drop it entirely. Copying wholesale would put
+internal detail in a public repository and leave rules no contributor here could follow.
+
+**Set `skip_specs: true` rather than author a token capability.** The change adds no
+runtime behaviour, and OpenSpec provides this marker precisely so a docs change is not
+forced to invent a requirement to pass validation.
+
+**Document the reporter contract by consequence, not by listing files.** The useful fact
+is not that `testrail.py` exists but that it is reached *per-case during a run*, so a
+failure there destroys results already collected. That framing is what makes a
+contributor cautious in the right place.
+
+## Risks / Trade-offs
+
+- **Documentation drifts from the code it describes** → Keep the file map at directory and
+  responsibility granularity, not function-by-function, so ordinary changes do not
+  invalidate it.
+- **The standards document is read as a mandate to reformat** → Stated explicitly in the
+  document itself, and again under scope discipline in `openspec/project.md`.
+- **Internal detail leaks into a public repository** → Every document is written for an
+  outside reader; anything naming a specific downstream product, tracker, host, or
+  internal process is out. Worth an explicit grep before the PR rather than trusting a
+  read-through.
+- **The red-then-green rule reads as bureaucratic for a trivial fix** → It is scoped to
+  behavioural changes; typo and docs changes are not covered.
+- **`AGENTS.md` duplicates `README.rst`** → They address different readers: `README.rst`
+  is for someone using the library, `AGENTS.md` for someone changing it. Keep the overlap
+  to the commands and cross-link rather than restate.
+
+## Migration Plan
+
+Not applicable — additive files only, nothing to deploy or roll back. Deleting the added
+files restores the previous state exactly.
+
+## Open Questions
+
+- Whether `CONTRIBUTING.md` and a PR template are wanted here, or whether
+  `openspec/project.md` covering the same ground is enough. Deferrable: it adds a file
+  without changing anything already written.
+- Whether release notes should be backfilled from 1.1.0 onward, and by whom. Deferrable
+  and better handled as its own change, since it means reconstructing three versions of
+  history.

--- a/openspec/changes/add-agent-docs/proposal.md
+++ b/openspec/changes/add-agent-docs/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+Spektrum carries no agent-facing documentation and a half-finished OpenSpec setup, so a
+coding agent — or a new human contributor — arrives with no statement of how the project
+is laid out, how it is tested, or what a change is expected to prove before it is opened
+for review. `openspec/` holds empty `specs/` and `changes/` trees but no `project.md` or
+`config.yaml`, so the tooling cannot actually be used against this repo.
+
+This matters more here than in an application. Spektrum is a library: a defect does not
+fail one test, it changes what every suite built on it reports, and it reaches every
+consumer at once. That risk profile needs to be written down, not rediscovered.
+
+## What Changes
+
+- Initialise OpenSpec properly: add `openspec/project.md` (the working rules) and
+  `openspec/config.yaml` (the schema declaration), so `openspec` commands operate on this
+  repo.
+- Add a root `AGENTS.md`, with `CLAUDE.md` symlinked to it: architecture summary, file
+  map, commands, and the reasoning behind non-obvious choices — chiefly that `tests/` is
+  pytest rather than Spektrum specs, because the framework cannot be its own harness when
+  the code under test is what renders the result.
+- Add `.claude/conventions.md`: the Python standards, scoped explicitly to new and
+  modified code so they do not read as a mandate to reformat the existing tree.
+- Record the reporter compatibility contract — `ExpectParams`, `ExpectFormatData` and the
+  reporters are what downstream output is rendered from, and `testrail.py` in particular
+  is reached per-case *during* a run, so a failure there can lose results already
+  collected rather than merely spoiling the final summary.
+- Establish the red-then-green rule: a behavioural change must show a test failing without
+  it and passing with it, and both counts belong in the PR.
+- Consider adding `CONTRIBUTING.md` and a PR template, which the repo currently lacks.
+
+No behaviour changes. No source file under `spektrum/` is touched.
+
+## Capabilities
+
+### New Capabilities
+
+None. This change adds documentation and project tooling only; it introduces no runtime
+behaviour and therefore no capability spec. `.openspec.yaml` sets `skip_specs: true`
+accordingly, rather than inventing a requirement to satisfy validation.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- **Added**: `openspec/project.md`, `openspec/config.yaml`, `AGENTS.md`, `CLAUDE.md`
+  (symlink), `.claude/conventions.md`. Possibly `CONTRIBUTING.md` and
+  `.github/pull_request_template.md`.
+- **Unchanged**: everything under `spektrum/` and `tests/`. No API, dependency, or
+  packaging change; no version bump.
+- **Audience**: contributors and coding agents. Nothing ships to users of the library.
+- **Constraint**: this repository is public. Every document must stay vendor-neutral — no
+  internal product names, tracker URLs, hostnames, or infrastructure detail. Rules
+  borrowed from a downstream project must be generalised, not copied, since much of what
+  such a project enforces is specific to its own environment and meaningless here.

--- a/openspec/changes/add-agent-docs/tasks.md
+++ b/openspec/changes/add-agent-docs/tasks.md
@@ -1,0 +1,100 @@
+> Items 1.x and 2.x are already implemented and committed on the working branch for this
+> change; they are checked off so the remaining work is visible at a glance. Everything
+> unchecked is still to do.
+
+## 1. Initialise OpenSpec
+
+- [x] 1.1 Add `openspec/config.yaml` declaring the `spec-driven` schema
+- [x] 1.2 Add `openspec/project.md` covering the PR procedure, the red-then-green rule,
+      scope discipline, and the reporter compatibility contract
+- [x] 1.3 Confirm `openspec status` and `openspec validate` run clean against the repo
+- [x] 1.4 Back-fill the specs for the live-view work that shipped in v1.3.0: bring the four
+      completed changes over from the `spektrum-live` branch, archive them so their
+      requirements are promoted into `openspec/specs/`, and write a real Purpose for each
+      capability. Without this the repo declares `schema: spec-driven` over an empty spec
+      baseline while the behaviour is already released
+
+## 2. Agent-facing documentation
+
+- [x] 2.1 Add root `AGENTS.md`: architecture summary, file map, commands
+- [x] 2.2 Explain in `AGENTS.md` why `tests/` is pytest rather than Spektrum specs, and
+      that `Expectation` built directly does not register with a spec
+- [x] 2.3 Symlink `CLAUDE.md` to `AGENTS.md` (do not create a second copy)
+- [x] 2.4 Add `.claude/conventions.md`, scoped in its own text to new and modified code
+- [x] 2.5 Cross-check the file map against the tree and correct any drift
+      - Drift found and corrected: `tests/reporting/` was listed but does not exist on
+        this branch, and `docs/` — the whole Sphinx tree — was missing from the map.
+        `transport.py` is `RetryTransport` for outbound reporter HTTP, not part of the
+        live view, and is now annotated as such
+- [x] 2.6 Correct the claim that `tests/` is pytest-only. `tests/live/` is 22 cases across
+      7 `Spec` classes, run by the CLI (`python -m spektrum -s tests/live/`); pytest
+      collects none of them, so a green `pytest tests` says nothing about them. AGENTS.md
+      documents both suites, and `openspec/project.md` and `.claude/conventions.md` were
+      corrected to match
+- [x] 2.7 Remove the invented `can_*` case-naming convention from AGENTS.md. `case_filter`
+      in `spektrum/spec.py` takes every public non-lifecycle method; `grep -rn 'def can_'`
+      over the tree returns nothing, so the prefix never existed
+- [x] 2.8 Stop presenting bare `tox` as a way to run the suite. `envlist` is
+      py36–py39 + pypy3 while CI tests only 3.12, so `tox` fails on absent interpreters
+      instead of running tests. AGENTS.md now points at `tox -e py312` / `tox -e flake8`
+- [x] 2.9 Correct `--coverage` in README.rst: it starts, stops and saves a coverage
+      session but never calls `report()`, so it writes `.coverage` and prints nothing
+
+- [x] 2.10 Document how to select what runs in README.rst. The README covered `-s`,
+      `--show-all-expects`, `-c`, `--xunit-results`, `--coverage` and the reporters, but
+      not `-p`, `-t` or `-m` -- the flags real usage reaches for first. Verified against a
+      throwaway spec tree by executing every command in the section, and recorded the two
+      non-obvious semantics: `-p "re:..."` is anchored at the end only
+      (`re.search(f'{pattern}$', ...)` in `runner.py`), while `-t "re:..."` is anchored at
+      both ends (`re.compile(f'^{name}$')` in `utils.py`) and is also matched against the
+      spaced form of the case name
+
+## 3. Public-repository audit
+
+- [x] 3.1 Grep every added document for internal product names, tracker URLs, hostnames
+      and infrastructure detail; the repository is public and rules borrowed from a
+      downstream project must be generalised, not copied
+      - The back-filled live specs named an internal downstream harness. Its requirement
+        was dropped from `openspec/specs/live-server-linger/spec.md` — a consumer's
+        obligation is not Spektrum's to specify — and the remaining mentions in the
+        archived proposal, design, tasks and delta were generalised
+- [x] 3.2 Apply the same grep to the commit messages on the branch, not only the files
+- [ ] 3.3 Read each document once as an outside contributor with no downstream context,
+      and cut anything that only makes sense from the inside
+
+## 4. Open questions to settle before finishing
+
+- [x] 4.1 Decide whether `CONTRIBUTING.md` is wanted, or whether `openspec/project.md`
+      already covers that ground (see design.md — Open Questions)
+      - Wanted. `openspec/project.md` is written for someone already inside the workflow
+        and is not a document a first-time outside contributor will find. CONTRIBUTING.md
+        is the conventional entry point on a public repo; it links to project.md for the
+        detail rather than restating it
+- [x] 4.2 Decide whether to add `.github/pull_request_template.md`
+      - Yes. The red-then-green rule only works if the PR form asks for both counts, and
+        the two-suite checklist is the one thing a contributor cannot guess
+- [x] 4.3 If either is wanted, write it and re-run the audit in section 3
+      - Both written; the section 3 grep was re-run over them and over the revised
+        README.rst and AGENTS.md
+
+## 5. Verification
+
+- [x] 5.1 Confirm no file under `spektrum/` or `tests/` was modified — this change is
+      documentation and tooling only
+- [x] 5.2 Run both suites and confirm the counts are unchanged from master: pytest
+      `1 passed`, and `python -m spektrum -s tests/live/` 22 passed / 121 expectations.
+      The branch touches no code, so both are unchanged by construction
+- [x] 5.3 Run `tox -e flake8` and confirm clean (`python -m flake8 spektrum tests`, exit 0)
+- [x] 5.4 Confirm no version bump and no release-note entry are included; this change
+      ships nothing to users of the library
+
+## 6. Review
+
+- [ ] 6.1 Rebase onto current `master` and resolve any drift in the file map
+- [ ] 6.2 Squash to a single commit, folding the verification counts and the reasoning
+      from the intermediate messages into the body. Note the two oldest commits on this
+      branch are already on `origin/MQ-3301`, so this rewrites published history and needs
+      a force-push — confirm nobody has built on the branch first
+- [ ] 6.3 Open the PR against `liquidweb/Spektrum`, base `master`, describing it as
+      docs-and-tooling-only with no behaviour change
+- [ ] 6.4 Archive this change once merged (`openspec archive`)

--- a/openspec/changes/archive/2026-03-17-live-assertion-streaming/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-17-live-assertion-streaming/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/archive/2026-03-17-live-assertion-streaming/design.md
+++ b/openspec/changes/archive/2026-03-17-live-assertion-streaming/design.md
@@ -1,0 +1,70 @@
+## Context
+
+The Spektrum live view (`--live`) runs an HTTP server that streams Server-Sent Events (SSE) to a browser. Currently the event flow is:
+
+1. `spec-discovered` — all cases registered as "pending" at startup
+2. `case-started` — case turns "running"
+3. `case-finished` — case turns passed/failed/skipped, assertions shown
+
+This means the assertions panel is always empty until the case completes. For long-running tests this can be many seconds with no visible progress.
+
+The `expect()` / `require()` functions in `expect.py` evaluate assertions synchronously during test execution. After each comparison, the result (pass/fail, label) is fully known and could be streamed immediately. The barrier is that `expect.py` has no reference to the event queue — it lives in `runner.py`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Stream each assertion result to the live view as it is evaluated, while the case is still `running`.
+- Keep changes minimal and contained to `expect.py`, `runner.py`, and `live.py` (+ HTML).
+- No changes to the public API (`expect`, `require`, `Spec`, CLI flags).
+
+**Non-Goals:**
+- Live streaming for non-live runs (pretty/xunit reporters are unaffected).
+- Streaming `before_each` / `after_each` assertions (only test-method assertions are in scope).
+- Persisting assertion history across browser refreshes beyond the existing snapshot mechanism.
+
+## Decisions
+
+### Decision 1: Use `contextvars.ContextVar` to pass the event queue into the expect layer
+
+**Rationale:** `expect.py` already walks the call stack to find the parent `Spec`. Extending that technique to also find the event queue works, but is fragile — it depends on specific frame names (`execute_test_case`). A `ContextVar` is the idiomatic Python mechanism for passing context through an async call chain without threading it explicitly through every function signature.
+
+`runner.py` sets the var in `execute_test_case` (using `token = _LIVE_CTX.set(...)`) before calling `execute_method`, and resets it after (`_LIVE_CTX.reset(token)`). The var carries `{ queue, spec_id, case_name }`.
+
+**Alternatives considered:**
+- Attaching `_live_event_queue` to the `Spec` instance — works, but pollutes the Spec with runner internals and can persist beyond a single test case.
+- Threading the queue through every function signature — invasive, touches many call sites.
+
+### Decision 2: Emit events from `Expectation._verify_condition`
+
+`_verify_condition` is the single point where `self.success` is set after a comparison. Emitting from here guarantees the event is sent exactly once per assertion, immediately after the result is known, regardless of which comparison method was called (`.equal`, `.be_true`, `.contain`, etc.).
+
+Emission uses `queue.put_nowait(...)` which is safe to call from synchronous code within an async event loop.
+
+**Alternatives considered:**
+- Emitting from each comparison method — requires touching every method, easy to miss new ones.
+- Emitting from `_add_expect_to_spec` — fires before the comparison result is known (`success` is still `False` at that point).
+
+### Decision 3: Live server converts `assertion-added` into a `case-update` SSE broadcast
+
+Rather than adding a new SSE event type for the browser to handle, the server translates `assertion-added` internal events into the existing `case-update` SSE format (same as `case-finished` but with `status: "running"` and partial `details`). This reuses all existing browser rendering logic with no HTML/JS changes except updating the existing assertions list in-place.
+
+## Risks / Trade-offs
+
+- **High-frequency tests**: A test with hundreds of assertions in a tight loop will put one event per assertion on the queue. The queue and SSE broadcast are both non-blocking (`put_nowait` + `asyncio` writes), so this is unlikely to be a bottleneck in practice, but could produce noisy diffs for fast tests.
+  → Mitigation: Acceptable for the initial implementation. A debounce/batch strategy can be added later if needed.
+
+- **`put_nowait` in a sync context**: `_verify_condition` is sync. `put_nowait` raises `QueueFull` if the queue has a `maxsize`. The existing queue is created without a size limit (`asyncio.Queue()`), so this is safe.
+  → Mitigation: Document the assumption; ensure the event queue stays unbounded.
+
+- **ContextVar and asyncio task isolation**: Each test case runs as a separate asyncio task via `asyncio.gather`. `ContextVar` values are inherited from the parent context at task creation time but mutations within a task are task-local. Setting and resetting within `execute_test_case` (which runs in the task) is safe.
+
+## Migration Plan
+
+All changes are additive and backward-compatible:
+1. Run is unchanged when `--live` is not used (`_LIVE_CTX` will be unset; `_verify_condition` no-ops the event path).
+2. No new CLI flags required.
+3. No database, schema, or file-format migrations.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-03-17-live-assertion-streaming/proposal.md
+++ b/openspec/changes/archive/2026-03-17-live-assertion-streaming/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Currently, the live view only shows assertions when a test case finishes — the assertions panel stays empty while a test is running, even if assertions have already been evaluated. This makes the live view less useful for long-running tests where you want to see progress in real time.
+
+## What Changes
+
+- Assertions are streamed to the live view as each one completes, not just after the test case finishes.
+- The live view updates the assertions list incrementally while a case is in `running` state.
+- No breaking changes to the existing public API (`expect`, `require`, `Spec`, CLI).
+
+## Capabilities
+
+### New Capabilities
+
+- `live-assertion-streaming`: Push each assertion result to the live server's event queue as it is evaluated, so the browser receives and displays assertion results while the test case is still running.
+
+### Modified Capabilities
+
+_(none — no existing spec-level requirements are changing)_
+
+## Impact
+
+- `spektrum/expect.py`: `Expectation._verify_condition` (or a hook after each comparison) must emit an event to the live event queue when one is active.
+- `spektrum/runner.py`: Before executing a test case, expose the event queue, `spec_id`, and `case_name` to the expect layer (via `contextvars`).
+- `spektrum/reporting/live.py`: Handle a new `assertion-added` internal event type; update in-memory case state and broadcast a `case-update` SSE event with the current assertions payload while the case is still `running`.
+- No changes to the CLI, reporters, or external integrations.

--- a/openspec/changes/archive/2026-03-17-live-assertion-streaming/specs/live-assertion-streaming/spec.md
+++ b/openspec/changes/archive/2026-03-17-live-assertion-streaming/specs/live-assertion-streaming/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Assertions stream to the live view as they are evaluated
+While a test case is running, the live view SHALL display each assertion result as soon as it is evaluated, without waiting for the case to finish.
+
+#### Scenario: Assertion appears while case is running
+- **WHEN** a running test case evaluates `expect(x).to.equal(y)`
+- **THEN** the live view SHALL show that assertion (with pass/fail state) in the case's detail panel before the case finishes
+
+#### Scenario: Multiple assertions stream incrementally
+- **WHEN** a running test case evaluates several assertions in sequence
+- **THEN** the live view SHALL display each assertion in the order it was evaluated, appending to the list as they arrive
+
+#### Scenario: Failed assertion streams immediately
+- **WHEN** a running test case evaluates an assertion that fails
+- **THEN** the live view SHALL show the failed assertion (red) immediately, while the case badge still shows `running`
+
+#### Scenario: Require assertion streams before halting
+- **WHEN** a running test case evaluates `require(x).to.be_true()` and the condition is false
+- **THEN** the live view SHALL display the failed require assertion before the case transitions to `failed`
+
+### Requirement: Live streaming is inactive when the live server is not running
+When Spektrum is run without `--live`, assertion evaluation SHALL NOT attempt to emit streaming events.
+
+#### Scenario: No event queue present
+- **WHEN** a test is run without `--live`
+- **THEN** assertion evaluation SHALL complete normally with no side effects from the streaming code path
+
+### Requirement: Browser shows in-progress assertions for a running case
+The live view HTML page SHALL update the assertions list for a case that is currently in `running` state when new assertion data arrives.
+
+#### Scenario: Assertions panel updates live
+- **WHEN** the browser receives a `case-update` SSE event for a `running` case that includes assertion data
+- **THEN** the assertions section in the case detail panel SHALL be re-rendered with the latest assertion list
+
+#### Scenario: Final case-update replaces running assertions
+- **WHEN** the browser receives a `case-update` SSE event with a terminal status (`passed`, `failed`, `skipped`)
+- **THEN** the full assertions list and final status SHALL replace the in-progress view

--- a/openspec/changes/archive/2026-03-17-live-assertion-streaming/tasks.md
+++ b/openspec/changes/archive/2026-03-17-live-assertion-streaming/tasks.md
@@ -1,0 +1,21 @@
+## 1. Context Variable Infrastructure
+
+- [x] 1.1 Add a `ContextVar` named `_LIVE_CTX` to `spektrum/expect.py` that holds `{ queue, spec_id, case_name }` or `None`
+
+## 2. Runner — Set Context Before Test Execution
+
+- [x] 2.1 In `execute_test_case` (`runner.py`), set `_LIVE_CTX` to `{ queue: event_queue, spec_id: spec._id, case_name: case.__name__ }` before calling `execute_method` for the test, and reset it after
+
+## 3. Expect — Emit Assertion Events
+
+- [x] 3.1 In `Expectation._verify_condition` (`expect.py`), after `self.success` is set, read `_LIVE_CTX`; if present, call `queue.put_nowait` with a new `assertion-added` event containing `spec_id`, `case_name`, and the assertion's `as_dict` payload
+
+## 4. Live Server — Handle `assertion-added` Events
+
+- [x] 4.1 In `LiveServer._consume_events` (`reporting/live.py`), add a handler for `assertion-added` that appends the assertion to the in-memory case state under `details.expects`
+- [x] 4.2 After updating state, broadcast a `case-update` SSE event with `status: "running"` and the current `details` payload (reusing the existing `_broadcast` helper)
+
+## 5. Tests
+
+- [x] 5.1 Add a test in `tests/live/` (or extend existing live tests) that verifies an `assertion-added` event is emitted to the queue when an assertion is evaluated during a live run
+- [x] 5.2 Add a test verifying that no event is emitted when `_LIVE_CTX` is not set (non-live run)

--- a/openspec/changes/archive/2026-03-17-live-run-context/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-17-live-run-context/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/archive/2026-03-17-live-run-context/design.md
+++ b/openspec/changes/archive/2026-03-17-live-run-context/design.md
@@ -1,0 +1,51 @@
+## Context
+
+`SpektrumRunner.run()` starts the live server (`live_server.start()`) before calling `PikeManager` for discovery. However, nothing is written to the event queue until `run_all()` executes — which happens after all discovery, instantiation, metadata filtering, and `before_all` setup. A connecting browser receives only an empty snapshot.
+
+The `search_paths` and `module_name` arguments to `run()` are exactly the user-supplied values that describe what is being run. They are available the moment the server starts.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Display search path and module filter in the browser as soon as a client connects, before any spec is discovered.
+- Keep the change minimal: one new event type, one new state field, one header UI update.
+
+**Non-Goals:**
+- Displaying metadata filters, concurrency, or other run parameters.
+- Changing when specs are discovered or when `before_all` runs.
+- Persisting run context across server restarts.
+
+## Decisions
+
+### Decision 1: Use a new `run-started` event emitted synchronously after server start
+
+A `run-started` event is placed on the queue immediately after `live_server.start()` returns, before entering `PikeManager`. The event carries `{ search_path, module_name }`.
+
+**Why:** The queue already handles ordering — `_consume_events` processes events in arrival order. Placing `run-started` first guarantees it is in the server's state before any `spec-discovered` event arrives. No new coordination mechanism is needed.
+
+**Alternatives considered:**
+- Passing run context directly to `LiveServer.__init__` — avoids the queue but couples the server constructor to runner arguments.
+- Sending run context as part of the snapshot only — works, but then the server needs the info at construction time, which has the same coupling problem.
+
+### Decision 2: Store run context in `LiveServer._run_context` and include it in every snapshot
+
+`_consume_events` stores the `run-started` payload in `self._run_context`. `_build_snapshot` includes it as a `run_context` field in the snapshot dict.
+
+New clients always receive a snapshot as their first event, so they will always see the run context immediately regardless of when they connect (before or after discovery).
+
+### Decision 3: Render run context in the HTML header subtitle
+
+The existing header has space for a subtitle below the "Spektrum Live" title. When `snapshot.run_context` is present the JS sets a subtitle element to the search path (and appends the module filter if set). No new SSE event type is needed on the browser side — the snapshot already carries the info.
+
+## Risks / Trade-offs
+
+- **`put_nowait` before consumer starts**: The consumer task (`_consume_events`) is started by `live_server.start()`. There is a small window where `put_nowait` is called before the consumer coroutine picks up the event. Because `asyncio.Queue` is unbounded, this is safe — the event waits in the queue until consumed.
+  → No mitigation needed.
+
+- **Minimal UI real estate**: The header already has a connection-status element on the right. The subtitle goes on the left below the title, keeping the existing layout intact.
+
+## Migration Plan
+
+No migration required. The change is purely additive:
+- Non-live runs are unaffected.
+- Existing clients that do not parse `run_context` in the snapshot will ignore the new field.

--- a/openspec/changes/archive/2026-03-17-live-run-context/proposal.md
+++ b/openspec/changes/archive/2026-03-17-live-run-context/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+When the live view server starts, the browser shows a blank page until spec discovery completes — there is no indication of what is being run or that anything is happening. For large suites, discovery and instantiation can take several seconds, leaving the user staring at an empty screen with no context.
+
+## What Changes
+
+- A `run-started` event is emitted to the event queue immediately after the live server starts, carrying the search path and optional module filter that were passed to the runner.
+- The live server stores this run context and includes it in every snapshot sent to new clients.
+- The live view HTML displays the search path (and module filter if set) in the header area as soon as the browser connects, before any specs are discovered.
+
+## Capabilities
+
+### New Capabilities
+
+- `live-run-context`: Capture and display the run's search path and module filter in the live view header from the moment the server starts.
+
+### Modified Capabilities
+
+_(none)_
+
+## Impact
+
+- `spektrum/runner.py`: Emit a `run-started` event immediately after `live_server.start()`.
+- `spektrum/reporting/live.py`: Handle `run-started` — store run context in server state; include it in snapshot payloads.
+- `spektrum/reporting/live.py` (HTML): Render search path and module filter in the page header when present.

--- a/openspec/changes/archive/2026-03-17-live-run-context/specs/live-run-context/spec.md
+++ b/openspec/changes/archive/2026-03-17-live-run-context/specs/live-run-context/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Runner emits run context immediately after server start
+After the live server starts, the runner SHALL emit a `run-started` event to the event queue containing the search path and optional module filter before any discovery or spec instantiation begins.
+
+#### Scenario: run-started event emitted with search path
+- **WHEN** the runner starts with `--live` and a search path
+- **THEN** a `run-started` event with `search_path` set SHALL be the first event in the queue
+
+#### Scenario: run-started event includes module filter when set
+- **WHEN** the runner starts with `--live` and a `-p module_name` filter
+- **THEN** the `run-started` event SHALL include `module_name` set to that filter value
+
+#### Scenario: run-started event emitted before spec-discovered
+- **WHEN** the runner starts with `--live`
+- **THEN** the `run-started` event SHALL appear in the queue before any `spec-discovered` event
+
+### Requirement: Live server stores run context and includes it in snapshots
+The live server SHALL store the run context from the `run-started` event and include it in every snapshot sent to connecting clients.
+
+#### Scenario: Snapshot includes run context after run-started received
+- **WHEN** a client connects after the `run-started` event has been processed
+- **THEN** the snapshot payload SHALL contain a `run_context` field with `search_path` and `module_name`
+
+#### Scenario: Snapshot run_context is null before run-started received
+- **WHEN** a client connects before the `run-started` event has been processed
+- **THEN** the snapshot payload SHALL contain `run_context: null`
+
+### Requirement: Live view displays run context in the header immediately on connect
+The live view HTML page SHALL display the search path (and module filter if present) in the header as soon as the snapshot is received, before any spec rows are rendered.
+
+#### Scenario: Search path shown in header
+- **WHEN** the browser receives a snapshot with `run_context.search_path` set
+- **THEN** the header SHALL display the search path value
+
+#### Scenario: Module filter shown alongside search path when present
+- **WHEN** the browser receives a snapshot with both `run_context.search_path` and `run_context.module_name` set
+- **THEN** the header SHALL display both the search path and the module filter
+
+#### Scenario: Header unchanged when run context absent
+- **WHEN** the browser receives a snapshot with `run_context: null`
+- **THEN** the header subtitle element SHALL remain empty

--- a/openspec/changes/archive/2026-03-17-live-run-context/tasks.md
+++ b/openspec/changes/archive/2026-03-17-live-run-context/tasks.md
@@ -1,0 +1,19 @@
+## 1. Runner — Emit run-started Event
+
+- [x] 1.1 In `runner.py`, after `live_server.start()`, call `self.event_queue.put_nowait({ 'type': 'run-started', 'search_path': search_paths[0], 'module_name': module_name })` (use the first search path; `module_name` may be None)
+
+## 2. Live Server — Handle run-started and Update Snapshot
+
+- [x] 2.1 Add `self._run_context = None` to `LiveServer.__init__`
+- [x] 2.2 In `_consume_events`, add a handler for `run-started` that sets `self._run_context = { 'search_path': event['search_path'], 'module_name': event.get('module_name') }`
+- [x] 2.3 In `_build_snapshot`, add `'run_context': self._run_context` to the returned dict
+
+## 3. HTML — Display Run Context in Header
+
+- [x] 3.1 Add a `<div id="run-context">` subtitle element to the header in `HTML_PAGE`, styled below the "Spektrum Live" title
+- [x] 3.2 In `handleSnapshot`, after processing specs, read `data.run_context` and set the subtitle element text to the search path (append `· <module_name>` if set)
+
+## 4. Tests
+
+- [x] 4.1 Add a test verifying `run-started` is the first event emitted to the queue when running with an event queue
+- [x] 4.2 Add a test verifying the live server snapshot includes `run_context` after processing a `run-started` event

--- a/openspec/changes/archive/2026-03-17-live-server-linger-delay/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-17-live-server-linger-delay/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/archive/2026-03-17-live-server-linger-delay/design.md
+++ b/openspec/changes/archive/2026-03-17-live-server-linger-delay/design.md
@@ -1,0 +1,38 @@
+## Context
+
+The live progress server (`LiveServer` in `spektrum/reporting/live.py`) currently shuts down immediately after the `run-complete` event is broadcast to SSE clients. For fast test suites (under a few seconds), the server may be gone before a developer can open a browser and navigate to `http://localhost:7777`. The linger delay solves this by holding the server open for a configurable number of seconds after `run-complete`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a `--live-linger` integer flag (seconds, default 5) to the Spektrum CLI
+- `LiveServer.shutdown()` sleeps for the linger duration before closing the TCP server
+- Print a notice to stdout indicating how long the server will remain up
+- Downstream harnesses forward `--live-linger` into the Spektrum argv (their own change)
+
+**Non-Goals:**
+- Dynamic linger (e.g., "wait until a client connects") — keep it simple and time-based
+- Per-client session management or reconnect detection
+
+## Decisions
+
+**Where the delay lives — `LiveServer.shutdown()` vs. `runner.run()`**
+
+The delay belongs inside `LiveServer.shutdown()`. The runner already `await`s `live_server.shutdown()` inside its `run_all()` coroutine, so a `asyncio.sleep()` there naturally holds the event loop open without any structural changes to the runner. Putting the delay in the runner would couple the runner to a concern that belongs to the server.
+
+**Default linger: 5 seconds**
+
+Five seconds is enough time to open a browser tab and type a localhost URL. It's not so long that it feels like the process is hanging. Users who need longer can override with `--live-linger 30`.
+
+**`--live-linger 0` disables linger entirely**
+
+Zero is the natural "no delay" value and backward-compatible. Current behavior (immediate shutdown) is preserved when `--live-linger 0` is passed or when `--live` is not used at all.
+
+**Countdown message vs. single notice**
+
+A single stdout message ("Live view staying up for N seconds...") is sufficient. A per-second countdown adds noise and requires a separate task; the user can see the browser loaded or not.
+
+## Risks / Trade-offs
+
+- [If the event loop exits before linger completes] → The `asyncio.sleep` in `shutdown()` is awaited within `run_all()`, which is itself inside `loop.run_until_complete()`, so the loop stays alive for the full duration.
+- [Linger adds wall-clock time to CI runs where `--live` is used] → Acceptable; `--live` is inherently a developer-facing flag, not typically used in CI. If CI does use it, passing `--live-linger 0` restores immediate shutdown.

--- a/openspec/changes/archive/2026-03-17-live-server-linger-delay/proposal.md
+++ b/openspec/changes/archive/2026-03-17-live-server-linger-delay/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+When tests run quickly, developers may not have enough time to open the live progress page before the server shuts down after `run-complete`. This makes the live view feature unusable for fast test suites. A configurable post-run delay keeps the server alive long enough for developers to load and review the results.
+
+## What Changes
+
+- Add a `--live-linger` CLI flag (default: 5 seconds) that controls how long the live server stays up after all tests complete
+- `LiveServer.shutdown()` waits the configured linger duration before closing, printing a countdown or notice to stdout
+- Downstream harnesses that shell out to Spektrum gain the corresponding flag and pass it
+  through (out of scope for this repository)
+
+## Capabilities
+
+### New Capabilities
+
+- `live-server-linger`: Post-run delay that holds the live progress server open for a configurable number of seconds after the test run completes, so developers can load and inspect the results page
+
+### Modified Capabilities
+
+<!-- none -->
+
+## Impact
+
+- `spektrum/__main__.py`: new `--live-linger` flag
+- `spektrum/runner.py`: passes linger value to `LiveServer`
+- `spektrum/reporting/live.py`: `LiveServer.__init__` and `shutdown()` updated to accept and apply linger delay
+- Downstream harness CLI (separate repository): new `--live-linger` flag passed through to
+  the Spektrum argv
+- `tests/live/test_live.py`: tests for linger behavior (server stays up, then closes)

--- a/openspec/changes/archive/2026-03-17-live-server-linger-delay/specs/live-server-linger/spec.md
+++ b/openspec/changes/archive/2026-03-17-live-server-linger-delay/specs/live-server-linger/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: Live server stays up after run completes
+The live progress server SHALL remain available for a configurable number of seconds after the `run-complete` event is broadcast, allowing developers time to load the results page in a browser.
+
+#### Scenario: Server stays up for linger duration
+- **WHEN** all tests complete and `--live-linger N` is set (N > 0)
+- **THEN** the live server continues accepting HTTP connections for at least N seconds before shutting down
+
+#### Scenario: Linger message printed to stdout
+- **WHEN** the live server enters its linger period
+- **THEN** a message is printed to stdout indicating how long the server will remain up (e.g., `Live view available for 5 more seconds...`)
+
+#### Scenario: Zero linger disables delay
+- **WHEN** `--live-linger 0` is passed
+- **THEN** the server shuts down immediately after broadcasting `run-complete`, matching pre-linger behavior
+
+### Requirement: CLI exposes linger flag
+The Spektrum CLI SHALL accept a `--live-linger` integer flag that specifies the post-run delay in seconds with a default of 5.
+
+#### Scenario: Default linger applied when flag omitted
+- **WHEN** `--live` is passed without `--live-linger`
+- **THEN** the server lingers for 5 seconds after the run completes
+
+#### Scenario: Custom linger value respected
+- **WHEN** `--live --live-linger 30` is passed
+- **THEN** the server lingers for 30 seconds after the run completes
+
+#### Scenario: Linger flag ignored without --live
+- **WHEN** `--live-linger N` is passed without `--live`
+- **THEN** no live server is started and the flag has no effect
+
+### Requirement: Downstream harnesses forward the linger flag
+A harness that invokes Spektrum as a subprocess SHALL be able to forward `--live-linger` into the
+Spektrum argv when `--live` is active. Implementing this is the harness's own responsibility and
+is not verified by this repository.
+
+#### Scenario: Harness forwards linger to spektrum
+- **WHEN** a harness is invoked with `--live --live-linger 10`
+- **THEN** `--live --live-port <port> --live-linger 10` are included in the Spektrum argv

--- a/openspec/changes/archive/2026-03-17-live-server-linger-delay/tasks.md
+++ b/openspec/changes/archive/2026-03-17-live-server-linger-delay/tasks.md
@@ -1,0 +1,25 @@
+## 1. CLI Flags
+
+- [x] 1.1 Add `--live-linger` integer flag (default 5) to `spektrum/__main__.py` `setup_argparse()`
+- [x] 1.2 Pass `live_linger` to `SpektrumRunner` instantiation in `spektrum/__main__.py` when `--live` is active
+- [x] 1.3 Add the matching `--live-linger` flag to the downstream harness CLI (tracked in that
+      repository, not this one)
+- [x] 1.4 In the downstream harness's Spektrum runner, extend argv with `--live-linger <value>`
+      when `--live` is active
+
+## 2. Runner and Server Wiring
+
+- [x] 2.1 Add `live_linger` parameter to `SpektrumRunner.__init__` (default 5) and store as `self.live_linger`
+- [x] 2.2 Pass `live_linger` to `LiveServer.__init__` when constructing the server in `runner.py`
+- [x] 2.3 Add `linger` parameter to `LiveServer.__init__` (default 5) and store as `self._linger`
+
+## 3. Linger Behavior in LiveServer
+
+- [x] 3.1 In `LiveServer.shutdown()`, after broadcasting `run-complete` to clients, print a linger notice to stdout if `self._linger > 0`
+- [x] 3.2 In `LiveServer.shutdown()`, `await asyncio.sleep(self._linger)` before closing the server (skip sleep when linger is 0)
+
+## 4. Tests
+
+- [x] 4.1 Add unit test: server with linger=0 shuts down without delay (assert elapsed time < 0.5s)
+- [x] 4.2 Add unit test: server with linger=2 stays up for ~2 seconds after shutdown is called (assert elapsed ≥ 1.5s)
+- [x] 4.3 Add unit test: linger notice is printed to stdout when linger > 0

--- a/openspec/changes/archive/2026-03-17-live-test-progress-view/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-17-live-test-progress-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-17

--- a/openspec/changes/archive/2026-03-17-live-test-progress-view/design.md
+++ b/openspec/changes/archive/2026-03-17-live-test-progress-view/design.md
@@ -1,0 +1,70 @@
+## Context
+
+Spektrum is an async Python BDD test runner. Test execution flows through `SpektrumRunner.run()` → `execute_spec()` → individual test method invocations. Results are collected by `ReportManager` and rendered after all tests complete. There is no mechanism to observe test state mid-run.
+
+The live progress view adds an optional HTTP server that runs alongside the test runner, receiving events as cases start and finish, and broadcasting them to a browser client over SSE. The browser renders the full spec/case tree with live status updates.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Opt-in live view with zero impact on existing test execution when not enabled
+- Real-time push of case state changes (started, passed, failed, skipped) to the browser
+- Mirror the final pretty-print hierarchy: spec → case, collapsible per case
+- No external runtime dependencies beyond what Spektrum already uses
+
+**Non-Goals:**
+- Replacing the existing pretty/xunit/testrail reporters
+- Persistent storage of test run history
+- Authentication or multi-user access to the live page
+- Mobile-optimized layout
+
+## Decisions
+
+### 1. SSE over WebSocket
+
+**Decision:** Use Server-Sent Events (SSE) rather than WebSockets for pushing updates to the browser.
+
+**Rationale:** The data flow is strictly one-directional: server → browser. SSE is simpler to implement (plain HTTP), works through proxies without special handling, and requires no client-side library. The `httpx` library already present as a dependency handles HTTP; a minimal `http.server` or `asyncio`-based server suffices.
+
+**Alternative considered:** WebSockets — adds bidirectional complexity with no benefit here.
+
+### 2. Embedded asyncio HTTP server (`aiohttp`-free)
+
+**Decision:** Implement the server using Python's `asyncio` streams or `http.server` in a background thread, avoiding new external dependencies.
+
+**Rationale:** Spektrum is a lightweight framework. Adding `aiohttp` or `fastapi` would bloat the install. A minimal asyncio TCP server serving SSE and static HTML is ~100 lines and has no new install requirements.
+
+**Alternative considered:** `aiohttp` — clean API but adds a heavy dependency; `flask` in thread — simpler but blocks GIL.
+
+### 3. Event bus via asyncio.Queue
+
+**Decision:** `SpektrumRunner` publishes events to an `asyncio.Queue`; `LiveServer` reads from the queue and broadcasts to connected SSE clients.
+
+**Rationale:** Decouples the runner from the server — the runner just puts events on a queue without knowing whether any clients are connected. This keeps the runner changes minimal and testable in isolation.
+
+### 4. Inline HTML/JS static asset
+
+**Decision:** The progress page HTML/CSS/JS is a single inline string embedded in `live.py`, not a file in a `static/` directory.
+
+**Rationale:** Keeps the package installable as a pure Python wheel without needing `package_data` configuration. The page is small enough to inline (~200 lines of HTML+JS).
+
+**Alternative considered:** `static/` directory with `package_data` — cleaner separation but adds packaging complexity.
+
+### 5. CLI flag `--live` with optional port
+
+**Decision:** Add `--live` flag (boolean) and `--live-port` (default 7777) to the docopt CLI.
+
+**Rationale:** Opt-in with a sensible default port. Separating the two flags avoids overloading `--live 7777` syntax.
+
+## Risks / Trade-offs
+
+- **Port conflict** → Mitigation: Graceful error message if port is in use; suggest `--live-port` to override.
+- **SSE client falls behind on very large/fast test runs** → Mitigation: Queue is unbounded; late-joining browser clients receive a full state snapshot on connection so they catch up immediately.
+- **Asyncio event loop sharing** → The live server runs in the same event loop as the test runner. Care needed to not block the loop. All server I/O must be non-blocking async. Mitigation: tested with `asyncio.sleep(0)` yield points.
+- **Browser JS complexity** → The tree rendering and collapsible dropdowns are plain vanilla JS with no framework. This is sufficient for a utility tool but limits future extensibility.
+
+## Migration Plan
+
+- No migration needed — feature is entirely additive behind the `--live` flag.
+- Existing users see no change unless they pass `--live`.
+- Rollback: remove the flag; `live.py` is isolated with no imports from it in the existing code path.

--- a/openspec/changes/archive/2026-03-17-live-test-progress-view/proposal.md
+++ b/openspec/changes/archive/2026-03-17-live-test-progress-view/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Spektrum currently only shows test results after all tests complete, giving no visibility into what's happening during a long test run. A live progress view would allow developers to monitor test execution in real-time, see which tests are running, which are pending, and review results as they come in — without waiting for the full suite to finish.
+
+## What Changes
+
+- Add a new HTTP server that serves a live progress page during test execution
+- Add a real-time WebSocket (or SSE) feed that pushes test state updates to the browser
+- Render the full spec/case hierarchy mirroring the final pretty output, with dynamic status badges
+- Each running case shows a "running" indicator; pending cases show "pending"; completed cases show pass/fail in a collapsible dropdown with result details
+- New CLI flag `--live` (or `--live-port <port>`) to opt into the live view server
+
+## Capabilities
+
+### New Capabilities
+- `live-progress-server`: HTTP server that launches alongside the test runner and serves a live test progress page with real-time updates via SSE or WebSocket
+- `progress-page-ui`: Browser-based UI that renders the full spec/case hierarchy with running/pending/complete status and collapsible result dropdowns
+
+### Modified Capabilities
+- `test-runner-lifecycle`: Runner emits progress events at case start, case end, and spec completion so the live server can consume and broadcast them
+
+## Impact
+
+- `spektrum/runner.py`: Emit lifecycle events (case started, case finished, spec finished)
+- `spektrum/reporting/core.py`: Hook into ReportManager or add a new parallel event bus for live updates
+- New module `spektrum/reporting/live.py`: HTTP + SSE/WebSocket server and event broadcaster
+- New static assets: HTML/CSS/JS for the progress page (embedded or served from a `static/` directory)
+- `spektrum/__main__.py`: New `--live` / `--live-port` CLI flag
+- No breaking changes to existing CLI flags or reporter interfaces

--- a/openspec/changes/archive/2026-03-17-live-test-progress-view/specs/live-progress-server/spec.md
+++ b/openspec/changes/archive/2026-03-17-live-test-progress-view/specs/live-progress-server/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Server starts when --live flag is provided
+When the `--live` CLI flag is passed, Spektrum SHALL start an HTTP server on the configured port (default 7777) before test execution begins and shut it down after all tests complete.
+
+#### Scenario: Server starts on default port
+- **WHEN** `spektrum --live -s tests/` is invoked
+- **THEN** an HTTP server SHALL be listening on port 7777 before any test runs
+
+#### Scenario: Server starts on custom port
+- **WHEN** `spektrum --live --live-port 9090 -s tests/` is invoked
+- **THEN** an HTTP server SHALL be listening on port 9090
+
+#### Scenario: Port conflict produces a clear error
+- **WHEN** `--live` is specified and the target port is already in use
+- **THEN** Spektrum SHALL print an error message naming the port and exit with a non-zero status code before running any tests
+
+### Requirement: Server serves the live progress page
+The HTTP server SHALL serve a self-contained HTML progress page at the root path (`/`).
+
+#### Scenario: Browser requests root path
+- **WHEN** a browser sends `GET /`
+- **THEN** the server SHALL respond with `200 OK`, `Content-Type: text/html`, and the full progress page HTML
+
+### Requirement: Server provides an SSE event stream
+The HTTP server SHALL expose a Server-Sent Events endpoint at `/events` that pushes test state changes to connected browsers.
+
+#### Scenario: Client connects to SSE endpoint
+- **WHEN** a browser sends `GET /events` with `Accept: text/event-stream`
+- **THEN** the server SHALL respond with `200 OK`, `Content-Type: text/event-stream`, and keep the connection open
+
+#### Scenario: Full state snapshot on connect
+- **WHEN** a client connects to `/events` after some tests have already run
+- **THEN** the server SHALL immediately emit a `snapshot` event containing the current state of all specs and cases
+
+#### Scenario: Live events pushed as cases change state
+- **WHEN** a test case transitions to running, passed, failed, or skipped
+- **THEN** the server SHALL push a `case-update` SSE event to all connected clients within 100ms of the transition
+
+### Requirement: Server shuts down cleanly after test run
+After all tests complete, the HTTP server SHALL remain available for a short grace period and then shut down, or shut down immediately if no clients are connected.
+
+#### Scenario: Graceful shutdown with no clients
+- **WHEN** all tests complete and no SSE clients are connected
+- **THEN** the server SHALL shut down immediately and Spektrum SHALL exit normally
+
+#### Scenario: Graceful shutdown with active clients
+- **WHEN** all tests complete and one or more SSE clients are connected
+- **THEN** the server SHALL push a `run-complete` event and then shut down within 5 seconds

--- a/openspec/changes/archive/2026-03-17-live-test-progress-view/specs/progress-page-ui/spec.md
+++ b/openspec/changes/archive/2026-03-17-live-test-progress-view/specs/progress-page-ui/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Page displays the full spec/case hierarchy
+The progress page SHALL render all discovered specs and their cases in a tree structure that mirrors the final pretty-print output, grouped by spec class name.
+
+#### Scenario: Hierarchy shown on page load
+- **WHEN** the page is loaded and a snapshot event has been received
+- **THEN** each spec SHALL be shown as a top-level section with its cases listed beneath it
+
+#### Scenario: Nested specs shown at correct depth
+- **WHEN** a spec contains nested child specs
+- **THEN** child specs SHALL be indented under their parent spec
+
+### Requirement: Running cases show a "running" status indicator
+Any test case currently executing SHALL be visually marked with a "running" status badge.
+
+#### Scenario: Case transitions to running
+- **WHEN** a `case-update` event with status `running` is received for a case
+- **THEN** that case SHALL display a "running" badge (e.g., spinner or distinct color) within one render cycle
+
+### Requirement: Pending cases show a "pending" status indicator
+Any test case that has not yet started SHALL be visually marked as "pending".
+
+#### Scenario: Initial page render shows pending cases
+- **WHEN** the page first renders cases from the snapshot
+- **THEN** all cases that have not yet started SHALL display a "pending" badge
+
+#### Scenario: Case remains pending until it starts
+- **WHEN** other cases in the same spec are running or complete
+- **THEN** cases that have not yet started SHALL continue to show "pending"
+
+### Requirement: Completed cases show result in a collapsible dropdown
+Each completed case (passed, failed, or skipped) SHALL display its result status and offer a collapsible section containing result details.
+
+#### Scenario: Passed case shows pass badge
+- **WHEN** a `case-update` event with status `passed` is received
+- **THEN** that case SHALL display a "passed" badge (e.g., green)
+
+#### Scenario: Failed case shows fail badge and expandable details
+- **WHEN** a `case-update` event with status `failed` is received
+- **THEN** that case SHALL display a "failed" badge (e.g., red) and a collapsed dropdown
+- **THEN** expanding the dropdown SHALL reveal the failure message and traceback
+
+#### Scenario: Skipped case shows skip badge
+- **WHEN** a `case-update` event with status `skipped` is received
+- **THEN** that case SHALL display a "skipped" badge and the skip reason in the collapsed dropdown
+
+#### Scenario: Passed case dropdown shows expect results
+- **WHEN** a passed case's dropdown is expanded
+- **THEN** it SHALL show the list of `expect()` assertion results for that case
+
+### Requirement: Page reconnects automatically if the SSE stream drops
+If the SSE connection to the server is lost, the page SHALL attempt to reconnect automatically.
+
+#### Scenario: Reconnection after disconnect
+- **WHEN** the SSE connection is lost (network hiccup or server restart)
+- **THEN** the browser SHALL attempt to reconnect within 3 seconds using the browser's built-in EventSource retry
+
+### Requirement: Page shows a completion banner when all tests finish
+When a `run-complete` event is received, the page SHALL display a summary banner with total pass/fail/skip counts.
+
+#### Scenario: Run complete banner appears
+- **WHEN** a `run-complete` SSE event is received
+- **THEN** the page SHALL display a banner with the counts of passed, failed, and skipped cases
+- **THEN** the page title SHALL update to reflect the final result (e.g., "✓ All passed" or "✗ 3 failed")

--- a/openspec/changes/archive/2026-03-17-live-test-progress-view/specs/test-runner-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-03-17-live-test-progress-view/specs/test-runner-lifecycle/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Runner accepts a live-event queue
+When a live event queue is provided to `SpektrumRunner`, the runner SHALL publish lifecycle events to it without affecting normal execution behavior.
+
+#### Scenario: No queue provided — no change in behavior
+- **WHEN** `SpektrumRunner` is used without `--live`
+- **THEN** no events SHALL be published and test execution SHALL behave identically to before
+
+#### Scenario: Queue provided — case-started event emitted
+- **WHEN** a live queue is configured and a test case begins execution
+- **THEN** the runner SHALL put a `case-started` event on the queue containing the spec name, case name, and timestamp
+
+#### Scenario: Queue provided — case-finished event emitted
+- **WHEN** a live queue is configured and a test case finishes execution
+- **THEN** the runner SHALL put a `case-finished` event on the queue containing spec name, case name, status (passed/failed/skipped), duration, and result details (failure message + traceback if failed; skip reason if skipped; expect results if passed)
+
+### Requirement: Runner emits a spec-discovered event for each spec before execution
+When a live queue is provided, the runner SHALL publish a `spec-discovered` event for every spec and case at discovery time, before any test runs.
+
+#### Scenario: All specs and cases announced before first test
+- **WHEN** a live queue is configured and discovery completes
+- **THEN** the runner SHALL emit one `spec-discovered` event per spec containing the spec's full case list, before any `case-started` event is emitted
+
+### Requirement: Runner emits a run-complete event after all tests finish
+When a live queue is provided, the runner SHALL publish a `run-complete` event after all specs and cases have finished executing.
+
+#### Scenario: Run-complete event contains summary counts
+- **WHEN** all tests finish
+- **THEN** the runner SHALL emit a `run-complete` event with totals: passed count, failed count, skipped count, and total duration

--- a/openspec/changes/archive/2026-03-17-live-test-progress-view/tasks.md
+++ b/openspec/changes/archive/2026-03-17-live-test-progress-view/tasks.md
@@ -1,0 +1,51 @@
+## 1. CLI and Configuration
+
+- [x] 1.1 Add `--live` boolean flag to the docopt CLI in `spektrum/__main__.py`
+- [x] 1.2 Add `--live-port` flag (default 7777) to the docopt CLI in `spektrum/__main__.py`
+- [x] 1.3 Pass the live flag and port through to `SpektrumRunner` instantiation
+
+## 2. Runner Lifecycle Events
+
+- [x] 2.1 Add an optional `event_queue: asyncio.Queue` parameter to `SpektrumRunner.__init__`
+- [x] 2.2 Emit a `spec-discovered` event for each spec with full case list after discovery, before execution begins
+- [x] 2.3 Emit a `case-started` event at the start of each test case execution
+- [x] 2.4 Emit a `case-finished` event at the end of each test case with status, duration, and result details
+- [x] 2.5 Emit a `run-complete` event after all specs finish with pass/fail/skip totals
+- [x] 2.6 Verify that when no queue is provided, runner behavior is unchanged
+
+## 3. Live Progress Server
+
+- [x] 3.1 Create `spektrum/reporting/live.py` with `LiveServer` class using asyncio
+- [x] 3.2 Implement root `GET /` handler returning the embedded progress page HTML
+- [x] 3.3 Implement `GET /events` SSE handler with proper `text/event-stream` headers and keep-alive
+- [x] 3.4 Implement SSE client registry — track connected clients and broadcast events to all of them
+- [x] 3.5 Implement snapshot logic: on new SSE client connection, emit current accumulated state as a `snapshot` event
+- [x] 3.6 Implement the event consumer loop that reads from the runner's `asyncio.Queue` and broadcasts to SSE clients
+- [x] 3.7 Implement port-conflict detection with a clear error message and non-zero exit
+- [x] 3.8 Implement graceful shutdown: push `run-complete` to connected clients, then close server within 5 seconds
+
+## 4. Progress Page UI (HTML/JS)
+
+- [x] 4.1 Design the inline HTML structure — spec sections, case rows, status badges
+- [x] 4.2 Implement CSS: pending/running/passed/failed/skipped badge colors, collapsible dropdown styles
+- [x] 4.3 Implement JavaScript `EventSource` connection to `/events` with automatic reconnect
+- [x] 4.4 Handle `snapshot` event: render the full spec/case tree from initial state
+- [x] 4.5 Handle `case-update` event: update the specific case row's status badge in-place
+- [x] 4.6 Implement collapsible dropdown per case: hidden by default, toggled on click
+- [x] 4.7 Populate dropdown content: failure message + traceback for failed; skip reason for skipped; expect results for passed
+- [x] 4.8 Handle `run-complete` event: display summary banner with pass/fail/skip counts and update page title
+- [x] 4.9 Embed the final HTML/CSS/JS as a string constant in `live.py`
+
+## 5. Integration
+
+- [x] 5.1 Wire `LiveServer` startup into `SpektrumRunner.run()` when `event_queue` is set — start server before first test
+- [x] 5.2 Wire `LiveServer` shutdown into runner teardown after all tests finish
+- [x] 5.3 Print the live URL to stdout when the server starts (e.g., `Live view: http://localhost:7777`)
+- [x] 5.4 Ensure the live server runs as an asyncio task in the same event loop as the runner without blocking test execution
+
+## 6. Tests
+
+- [x] 6.1 Add unit tests for runner event emission (mock queue, assert events published)
+- [x] 6.2 Add unit tests for `LiveServer` SSE broadcast logic (connect client, emit event, assert received)
+- [x] 6.3 Add integration test: run a sample spec with `--live`, connect to `/events`, assert snapshot and case-update events arrive
+- [x] 6.4 Add test for port-conflict error path

--- a/openspec/changes/enforce-sdd-and-audit-docs/.openspec.yaml
+++ b/openspec/changes/enforce-sdd-and-audit-docs/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-26
+skip_specs: true

--- a/openspec/changes/enforce-sdd-and-audit-docs/design.md
+++ b/openspec/changes/enforce-sdd-and-audit-docs/design.md
@@ -1,0 +1,117 @@
+## Context
+
+See proposal.md — Why. Three constraints shape the approach:
+
+**The `openspec` CLI is a Node package.** `.travis.yml` is a Python-only matrix
+(`TOXENV=py312`, `TOXENV=flake8`) that also owns the PyPI deploy on tags. Any check that
+invokes `openspec` needs a Node toolchain the current CI does not have.
+
+**`openspec/project.md` is legacy.** OpenSpec 1.9.0's `legacy-cleanup` module lists
+"AGENTS.md and project.md" as legacy structure files and preserves `project.md` for manual
+migration. `openspec instructions <artifact> --json` returns no `context` field for this
+repo, so nothing the CLI hands an agent mentions the project's rules.
+
+**`/opsx:apply` is the only command that writes source, and it is user-level.** It lives in
+`~/.claude/commands/opsx/apply.md`, outside this repository, and its context comes from
+`openspec instructions apply --json`, whose `contextFiles` are the change's own artifacts.
+The repo cannot edit that file, only shadow it.
+
+What *does* load reliably is `CLAUDE.md`, symlinked to `AGENTS.md`: the harness reads it for
+the working directory at session start. That is the one hook the repository controls.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A merge-blocking check that a behaviour change arrives with a spec or change document.
+- The conventions reach the agent writing the code, in a session or a subagent.
+- The published documentation describes the code that exists.
+- Drift is measured by a command, so the next audit is repeatable.
+
+**Non-Goals:**
+
+- Writing specs for the unspecified library surface. This change inventories the gap; each
+  capability needs authored requirements and review, which would swamp one change.
+- Replacing Travis. The test matrix and the tag-triggered PyPI deploy stay where they are.
+- Fixing the three known code defects (proposal.md — Impact, tasks.md 1.3). Each changes
+  behaviour and so earns its own change.
+
+## Decisions
+
+**A GitHub Actions workflow for the SDD gate, not a Travis job.** Travis would need Node
+added to a Python matrix, slowing every build and coupling the test lane to a tool it does
+not otherwise use — for a check that has nothing to do with running tests. A separate
+workflow keeps one job per concern: Travis proves the code works, Actions proves the
+process was followed. *Alternative considered:* a pure-Python path check inside Travis,
+needing no Node. Rejected because it can compare changed paths but cannot run
+`openspec validate --all`, which is the half that catches a malformed spec.
+
+**The gate is path-based with a labelled escape hatch.** It fails when the diff touches
+`spektrum/` but nothing under `openspec/`, and passes when a `no-spec` label is present.
+Attempting to distinguish a "real" behaviour change from a docstring fix by parsing the diff
+is a heuristic that will be wrong in both directions; a human applying a label is honest
+about who made the judgment. *Alternative considered:* warn instead of fail. Rejected —
+proposal.md's premise is that an unenforced rule is a suggestion.
+
+**`project.md` stays the authority; the repo shadows `/opsx:apply` to load it.** Moving the
+working agreement into `AGENTS.md` would push that file well past the length at which it
+stops being read, and OpenSpec preserves `project.md` precisely so it can keep serving this
+purpose. The fix for the tooling gap is a repo-level `.claude/commands/opsx/apply.md` that
+adds reading `openspec/project.md` and `.claude/conventions.md` as its first step, before
+any file is edited. `AGENTS.md` gains one line recording that the CLI does *not* read
+`project.md`, so nobody mistakes preservation for enforcement. *Alternative considered:*
+`openspec init --tools claude` to regenerate current-format integration. Rejected: it
+writes tool integrations into the repo that would duplicate the user-level `opsx` commands
+already installed, and the duplication resolves unpredictably.
+
+**Delete `docs/parallel/index.rst` rather than revise it.** It describes distributing tests
+across Python processes with `--parallel` and `--num-processes`; the runner is asyncio with
+semaphores bounded by `--concurrency`, and the chapter's framing — separate processes,
+different reporting — is wrong at the premise, not in its details. Concurrency gets a
+section in `docs/using/`. Git keeps the old page for anyone who wants it.
+
+**The audit is a Python script in `tools/`, replacing the shell relic there.** It reports
+flags documented but absent from `setup_argparse()`, flags present but undocumented,
+`setup.py`'s version against the newest release-note entry, and capabilities under
+`spektrum/` with no spec. Python because the repo is Python and the script can import the
+CLI's own parser rather than grepping for flags. It exits non-zero on drift so it can be
+wired into the gate later, but this change does not wire it in — a drift check that fails
+on day one blocks every unrelated PR.
+
+## Risks / Trade-offs
+
+- **The path gate fires on legitimate non-behavioural edits** (a typo in a docstring, a
+  lint fix) → the `no-spec` label clears it in one click, and the PR template's blast-radius
+  field already asks the author to think about scope.
+- **Two CI systems drift apart, or a contributor cannot tell which failure matters** →
+  the workflow is named for what it checks, and `CONTRIBUTING.md` states which system owns
+  tests and which owns process.
+- **Deleting a docs chapter loses information if some consumer still runs a version with
+  `--parallel`** → the release notes, once brought current, are where a reader on an old
+  version looks; the chapter as written misleads every reader on 1.3.0.
+- **The `opsx:apply` override diverges from the user-level command it shadows** as that
+  command is updated upstream → the override adds a step and delegates the rest rather than
+  copying the file, so it inherits changes instead of freezing them.
+- **`skip_specs: true` on a change about enforcing specs reads as a contradiction** →
+  proposal.md — Capabilities states the reasoning; the alternative is a fabricated
+  requirement in the baseline this change exists to make trustworthy.
+
+## Migration Plan
+
+No deployment and no rollback: nothing ships to users of the library. The one ordering
+constraint is that the Actions workflow lands *after* the docs corrections, so the first
+run of the gate is not the PR that introduces it failing against itself.
+
+## Open Questions
+
+- ~~**Is Travis still running for this repository?**~~ **Resolved: yes.** Confirmed by the
+  maintainer against a build on an open MQ-3300 PR, which ran and passed. Travis therefore
+  keeps tests, lint and the tag-triggered PyPI deploy, and the new workflow is the SDD gate
+  and nothing else — the smaller of the two shapes this change could have taken. The badge
+  in `docs/index.rst` still points at `travis-ci.org`, which shut down for open-source
+  builds, so the image is broken even though the builds are not; that is a docs fix, not a
+  CI one.
+- **Should the docs be published anywhere?** `docs/` is a complete Sphinx tree with no
+  configured host and no URL in `setup.py`. Correcting docs nobody can read is worth less
+  than correcting them and publishing them, but choosing a host is a decision for the
+  maintainer.

--- a/openspec/changes/enforce-sdd-and-audit-docs/proposal.md
+++ b/openspec/changes/enforce-sdd-and-audit-docs/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The repository is about to gain a spec-driven workflow that nothing enforces and that the
+tooling no longer reads. `openspec/project.md` — the file this project treats as its
+working agreement — is classified as **legacy structure** by OpenSpec 1.9.0: preserved on
+disk, never fed to an agent. Nothing in `/opsx:apply` or the `openspec` CLI surfaces the
+repo's conventions, so the workflow can be followed to the letter and still produce code
+that ignores the house rules. Meanwhile the published Sphinx documentation describes a
+version of Spektrum that no longer exists.
+
+The gap is measurable rather than theoretical. `docs/` documents eight command-line flags
+that were removed (`--parallel`, `--num-processes`, `--tags`, `--no-color`, `--no-art`,
+`--ascii-only`, `--json-results`) and omits thirteen that exist (the whole `--tr-*` set,
+`--live`/`--live-port`/`--live-linger`, `--concurrency`, `--dry-run`,
+`--exclude-by-metadata`). `docs/parallel/index.rst` explains a multi-process architecture
+that asyncio and semaphores replaced. `docs/release_notes/index.rst` stops at 1.0.0 while
+`setup.py` says 1.3.0 — three releases with no notes. And the spec baseline covers only
+the live view: roughly 4,000 lines of runner, expectation and reporting code have no spec
+at all, so "spec-driven" currently describes one feature rather than the library.
+
+## What Changes
+
+- **Enforce the workflow in CI.** Add a check that fails when `spektrum/` changes without a
+  corresponding change under `openspec/`, and that runs `openspec validate --all`. A rule
+  no build enforces is a suggestion.
+- **Make the conventions reachable by the agent that writes the code.** `/opsx:apply` is
+  the one command that edits source, and it reads only the change's own artifacts. Route
+  `.claude/conventions.md` and the PR procedure into it, and resolve `project.md`'s legacy
+  status so the rules live somewhere the tooling actually loads.
+- **Correct the published documentation.** Remove or rewrite the flags and the parallel
+  chapter that no longer describe the code, document the thirteen undocumented flags, and
+  bring the release notes up to 1.3.0.
+- **Inventory the spec gap.** Produce a list of the library's unspecified capabilities,
+  ranked, so back-filling them becomes scheduled work rather than an open-ended intention.
+  Writing those specs is deliberately *not* in this change — see Impact.
+- **Verify the audit claims hold.** Every drift figure above was measured; the same checks
+  become a repeatable script so the next audit is a command rather than an afternoon.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — see below)_
+
+### Modified Capabilities
+
+_(none — see below)_
+
+This change sets `skip_specs: true`. It alters no Spektrum behaviour: every deliverable is
+documentation, repository tooling, or CI configuration. The library's public surface, its
+CLI flags and its reporters behave identically before and after. Specs describe behaviour,
+so inventing a requirement here to satisfy validation would put a false entry in the
+baseline this change exists to make trustworthy.
+
+## Impact
+
+- `docs/using/`, `docs/parallel/`, `docs/reporting/`, `docs/release_notes/` — the stale
+  chapters. `docs/parallel/index.rst` may warrant deletion rather than revision.
+- `.github/workflows/` — new; the repository currently has no Actions workflow, only the
+  PR template. `.travis.yml` is the existing CI and stays authoritative for tests and lint.
+- `.claude/` — a repo-level `opsx:apply` override, so the conventions load regardless of
+  which session or subagent runs it.
+- `openspec/project.md` and `AGENTS.md` — whichever becomes the authority, exactly one of
+  them must be it.
+- `tools/` — the audit script lands here; note `tools/run_tests.sh` is already stale
+  (`nosetests`) and is a candidate for removal in passing.
+- **Not touched:** `spektrum/` and `tests/`. Three known code defects are deliberately out
+  of scope, because each changes behaviour and so needs its own change with a real spec: the
+  `--tr-endpoint` default pointing at a private TestRail tenant, `spec_filter` raising
+  `AttributeError` on a nested non-`Spec` class, and `-p`/`-t`'s help text never mentioning
+  the `re:` prefix that makes the feature discoverable.

--- a/openspec/changes/enforce-sdd-and-audit-docs/tasks.md
+++ b/openspec/changes/enforce-sdd-and-audit-docs/tasks.md
@@ -1,0 +1,117 @@
+## 1. Establish the ground before building on it
+
+- [x] 1.1 Confirm whether Travis still builds this repository. **It does** — verified by
+      the maintainer against a build on an open MQ-3300 PR, which ran and passed. So
+      `.travis.yml` stays authoritative for tests, lint and the tag-triggered PyPI deploy,
+      and section 5's workflow is scoped to the SDD gate alone. No CI-migration proposal is
+      needed.
+- [ ] 1.2 Re-measure the drift figures in proposal.md — Why against the current tree, so the
+      work starts from numbers rather than from a claim made earlier.
+- [ ] 1.3 Confirm the three deferred code defects are still present and still out of scope:
+      the `--tr-endpoint` default pointing at a private TestRail tenant, `spec_filter`
+      raising `AttributeError` on a nested non-`Spec` class, and `-p`/`-t`'s help text not
+      mentioning the `re:` prefix at all (`-p` reads only "Selects a module path to run.
+      Ex: sample.TestClass"), which makes the feature undiscoverable outside the source.
+      Each gets its own change.
+
+## 2. Correct the published documentation
+
+- [ ] 2.1 `docs/using/index.rst`: remove the flags that no longer exist (`--no-color`,
+      `--no-art`, `--ascii-only`, `--json-results`, `--tags`) and correct `--search` usage
+      to match `setup_argparse()`.
+- [ ] 2.2 Document the thirteen flags that exist and are undocumented: `--concurrency`,
+      `--dry-run`, `--exclude-by-metadata`, `--live`, `--live-port`, `--live-linger`, and
+      the seven `--tr-*` options. Group them by what a reader is trying to do, not
+      alphabetically.
+- [ ] 2.3 Delete `docs/parallel/index.rst` and its `toctree` entry. It documents
+      `--parallel` / `--num-processes` distributing tests across processes; the runner is
+      asyncio with semaphores. Add a concurrency section to `docs/using/index.rst` covering
+      `--concurrency` instead.
+- [ ] 2.4 `docs/release_notes/index.rst`: add entries for 1.1.x, 1.2.x and 1.3.0. Derive
+      them from the git log between the release tags, not from memory.
+- [ ] 2.5 `docs/index.rst`: the CI badge and its link point at
+      `https://travis-ci.org/liquidweb/Spektrum`, which shut down for open-source builds —
+      the image is broken although the builds still run. Repoint both at the host actually
+      serving them, or drop the badge if it cannot be pointed anywhere useful.
+- [ ] 2.6 `docs/reporting/index.rst`: replace the sample `class_path` value
+      (`spec.rift.clients.ssh.SSHCredentials.KeyBased`) with a neutral example. It names an
+      internal project in a public repository.
+- [ ] 2.7 Document the `re:` prefix and its anchoring in `docs/using/index.rst`, matching
+      the README section: `-p` anchors at the end only, `-t` at both ends and also against
+      the spaced form of the case name. `--exclude-by-metadata` appears in no doc file at
+      all today.
+- [ ] 2.8 Re-read `docs/index.rst`, `docs/writing_tests/`, `docs/maintenance/` for the same
+      class of drift the flag diff cannot catch — removed concepts described in prose.
+- [ ] 2.9 Build the docs (`cd docs && make html`) and confirm no Sphinx warnings are
+      introduced by the edits.
+
+## 3. Make drift measurable
+
+- [ ] 3.1 Add `tools/audit_docs.py`: import `setup_argparse()` and diff its flags against
+      those mentioned under `docs/`, compare `setup.py`'s version with the newest
+      release-note entry, and list modules under `spektrum/` with no corresponding spec.
+      Import the parser rather than grepping for flags.
+- [ ] 3.2 Exit non-zero on drift, and document in `AGENTS.md` — Commands how to run it.
+      Do **not** wire it into CI in this change: a drift check that fails on day one blocks
+      every unrelated PR.
+- [ ] 3.3 Delete `tools/run_tests.sh`. It calls `nosetests`, which cannot run on 3.12, and
+      `AGENTS.md` already flags it as stale.
+
+## 4. Route the conventions to the agent that writes the code
+
+- [ ] 4.1 Add `.claude/commands/opsx/apply.md` shadowing the user-level command: read
+      `openspec/project.md` and `.claude/conventions.md` as step one, before any file is
+      edited, then delegate the rest. Add the step; do not copy the upstream file, so it
+      inherits future changes.
+- [ ] 4.2 Add one line to `AGENTS.md` recording that OpenSpec 1.9.0 treats
+      `openspec/project.md` as legacy structure — preserved, never fed to an agent — so
+      nobody mistakes preservation for enforcement.
+- [ ] 4.3 Verify the override actually loads: run `/opsx:apply` against a trivial task and
+      confirm the conventions were read before the edit.
+
+## 5. Enforce the workflow in CI
+
+- [ ] 5.1 Add `.github/workflows/` with a job that fails when the diff touches `spektrum/`
+      and nothing under `openspec/`. Honour a `no-spec` label as the escape hatch.
+- [ ] 5.2 Add `openspec validate --all` to that workflow, on Node, so a malformed spec or
+      change is caught rather than merely a missing one.
+- [ ] 5.3 Name the workflow for what it checks, and state in `CONTRIBUTING.md` which CI
+      system owns tests and lint versus which owns process, so a contributor can tell which
+      red build matters.
+- [ ] 5.4 Land this group **after** section 2, so the gate's first run is not the PR that
+      introduces it failing against itself.
+
+## 6. Inventory the spec gap
+
+- [ ] 6.1 List every capability under `spektrum/` with no spec — the runner's execution
+      tree, expectation construction and source lookup, case and spec selection, the
+      console/xunit/TestRail reporters, the CLI surface — ranked by blast radius.
+- [ ] 6.2 Record the inventory where the next person will find it, and state plainly that
+      the current baseline covers the live view only. Writing those specs is **not** part of
+      this change; each capability becomes its own proposal.
+
+## 7. Verification
+
+- [ ] 7.1 Confirm no file under `spektrum/` or `tests/` was modified: this change is docs,
+      tooling and CI only.
+- [ ] 7.2 `python -m pytest tests -q` — record the count. It must match the count before
+      the change.
+- [ ] 7.3 `python -m spektrum -s tests/live/` — record the count (pytest does not collect
+      these, and under `python -m` a nonexistent search path exits 0).
+- [ ] 7.4 `tox -e flake8` clean, including `tools/audit_docs.py`.
+- [ ] 7.5 `openspec validate --all` passes.
+- [ ] 7.6 `tools/audit_docs.py` reports no drift, which is the real proof section 2 worked.
+- [ ] 7.7 Public-repository audit: grep every added and edited file for internal product
+      names, private hostnames and tracker URLs, and apply the same grep to this branch's
+      commit messages.
+
+## 8. Review
+
+- [ ] 8.1 Read each edited doc once as an outside contributor with no context, and cut
+      anything that only makes sense from the inside.
+- [ ] 8.2 Rebase onto current `master` and resolve drift in the flag lists and the file map.
+- [ ] 8.3 Squash to a single commit, keeping the measured drift figures and the CI
+      decision from task 1.1 in the message body.
+- [ ] 8.4 Open the PR against `liquidweb/Spektrum`, base `master`, describing it as
+      docs-tooling-and-CI only with no behaviour change.
+- [ ] 8.5 Archive this change once merged (`openspec archive enforce-sdd-and-audit-docs`).

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,118 @@
+# Project rules — Spektrum
+
+Spektrum is a **library**: a test framework other projects depend on. That single fact
+drives every rule below. A defect here does not fail one test — it silently changes what
+every suite built on it reports, and a breaking change lands in every consumer at once.
+
+## Before opening a PR — MANDATORY
+
+### 1. Prove the change with a red-then-green run
+
+Every behavioural change needs a test that **fails without the change and passes with
+it**, and the PR must show both numbers. A test written after the fix, never observed
+failing, proves only that it agrees with the code as written.
+
+The mechanical way to get both, without disturbing anything else in the tree:
+
+```shell
+git stash push -- <the source files you changed>
+python -m pytest tests -q          # RED — record the count
+git stash pop
+python -m pytest tests -q          # GREEN — record the count
+```
+
+Substitute `python -m spektrum -s tests/live/` for the pytest line when the change is
+covered by the spec suite instead — see the next section.
+
+Paste both counts into the PR. Collection-only checks are not verification; only an
+executed suite is.
+
+### 2. Run **both** suites, not just your file
+
+```shell
+python -m pytest tests -q
+python -m spektrum -s tests/live/
+```
+
+`tests/` holds two suites with different runners, and neither runs the other. `pytest`
+does not collect `tests/live/` — those are `Spec` subclasses, so pytest silently
+reports success while leaving them untouched. Running one suite and calling the tree green
+is the easiest way to ship a regression here.
+
+A reporting change can pass its own tests and still break the runner, because the
+reporters are reached through `SpektrumRunner`, not directly. Both suites together are
+cheap — there is no excuse for scoping it down.
+
+### 3. Lint
+
+```shell
+tox -e flake8      # or: python -m flake8 spektrum tests
+```
+
+Max line length is 100; `H301,H405,H702,W503` are ignored. `spektrum/vendor/*` is
+excluded and must stay that way — never reformat vendored code.
+
+### 4. Any failure means no PR
+
+A red suite is not a discussion. Fix it, or explain to the maintainer why the failure is
+expected and let **them** decide — never rule a failure acceptable on your own.
+
+### 5. Squash to a single commit
+
+A PR is **one commit**. Work in as many commits as you like while the branch is local —
+they are the record of how you got there — then collapse them before review:
+
+```shell
+git reset --soft $(git merge-base master HEAD)
+git commit          # one subject, and a body that keeps the evidence
+```
+
+The body is where the intermediate messages go, not the bin. Fold in the counts from the
+red-then-green run, anything a reviewer would otherwise have to reconstruct, and the
+reasoning behind decisions that are not obvious from the diff.
+
+Two cases where this needs care:
+
+- **Commits already pushed.** Squashing rewrites published history and needs a
+  force-push. Confirm nobody has built on the branch first, and never force-push a branch
+  someone else is working from.
+- **A change that is genuinely two changes.** If the diff cannot be described in one
+  subject line without an "and", that is the signal to open two PRs, not to keep two
+  commits in one.
+
+### 6. Green → open the PR
+
+Target `liquidweb/Spektrum`, base `master`. Paste every run into the PR body.
+
+## Scope discipline
+
+- **Fix only what the branch is for.** A checker or reviewer surfacing pre-existing
+  problems in a file you touched is not a licence to widen the diff. Report them; open a
+  separate issue.
+- **Do not reformat.** This repo predates several conventions applied to newer code
+  (`except Exception:` in `raise_a`, mixed quote styles). Leaving them is deliberate:
+  churn buries the real change in review.
+- **Never stage broadly.** `git add -A` can sweep up unrelated in-progress work. Stage
+  explicit paths and check `git status` before committing.
+
+## Compatibility
+
+`ExpectParams`, `ExpectFormatData` and the reporters form the contract that downstream
+output is rendered from. Before changing what a property returns, check the consumers:
+
+- `spektrum/reporting/pretty.py` — the default console reporter.
+- `spektrum/reporting/testrail.py` — reached **per-case during a run**, so a failure here
+  can lose results already collected, mid-run, rather than merely at the end.
+- `spektrum/reporting/xunit.py`, `live.py` — CI and live-view output.
+
+Prefer widening a guard over changing a return type. Returning `None` where a caller
+expects a string moves a crash into a downstream label rather than removing it.
+
+## Git
+
+- **Branch:** named for the issue or ticket being worked.
+- **Commit subject:** `<id>: <description>`, imperative mood.
+- **One commit per PR.** Squash before review — see *Before opening a PR*, step 5.
+- **Base:** `master` on `liquidweb/Spektrum`. `origin` is normally a personal fork, so
+  anything resolving `origin/HEAD` is looking at the wrong baseline.
+- **Do not commit or push unless asked.**

--- a/openspec/specs/live-assertion-streaming/spec.md
+++ b/openspec/specs/live-assertion-streaming/spec.md
@@ -1,0 +1,44 @@
+# live-assertion-streaming Specification
+
+## Purpose
+Stream each assertion result to the live view as it is evaluated, so a long-running
+case shows its progress instead of an empty panel until it finishes.
+
+## Requirements
+
+### Requirement: Assertions stream to the live view as they are evaluated
+While a test case is running, the live view SHALL display each assertion result as soon as it is evaluated, without waiting for the case to finish.
+
+#### Scenario: Assertion appears while case is running
+- **WHEN** a running test case evaluates `expect(x).to.equal(y)`
+- **THEN** the live view SHALL show that assertion (with pass/fail state) in the case's detail panel before the case finishes
+
+#### Scenario: Multiple assertions stream incrementally
+- **WHEN** a running test case evaluates several assertions in sequence
+- **THEN** the live view SHALL display each assertion in the order it was evaluated, appending to the list as they arrive
+
+#### Scenario: Failed assertion streams immediately
+- **WHEN** a running test case evaluates an assertion that fails
+- **THEN** the live view SHALL show the failed assertion (red) immediately, while the case badge still shows `running`
+
+#### Scenario: Require assertion streams before halting
+- **WHEN** a running test case evaluates `require(x).to.be_true()` and the condition is false
+- **THEN** the live view SHALL display the failed require assertion before the case transitions to `failed`
+
+### Requirement: Live streaming is inactive when the live server is not running
+When Spektrum is run without `--live`, assertion evaluation SHALL NOT attempt to emit streaming events.
+
+#### Scenario: No event queue present
+- **WHEN** a test is run without `--live`
+- **THEN** assertion evaluation SHALL complete normally with no side effects from the streaming code path
+
+### Requirement: Browser shows in-progress assertions for a running case
+The live view HTML page SHALL update the assertions list for a case that is currently in `running` state when new assertion data arrives.
+
+#### Scenario: Assertions panel updates live
+- **WHEN** the browser receives a `case-update` SSE event for a `running` case that includes assertion data
+- **THEN** the assertions section in the case detail panel SHALL be re-rendered with the latest assertion list
+
+#### Scenario: Final case-update replaces running assertions
+- **WHEN** the browser receives a `case-update` SSE event with a terminal status (`passed`, `failed`, `skipped`)
+- **THEN** the full assertions list and final status SHALL replace the in-progress view

--- a/openspec/specs/live-progress-server/spec.md
+++ b/openspec/specs/live-progress-server/spec.md
@@ -1,0 +1,55 @@
+# live-progress-server Specification
+
+## Purpose
+The HTTP server behind `--live`: it serves the live progress page and the SSE event
+stream for a run, and shuts down cleanly once the run is over.
+
+## Requirements
+
+### Requirement: Server starts when --live flag is provided
+When the `--live` CLI flag is passed, Spektrum SHALL start an HTTP server on the configured port (default 7777) before test execution begins and shut it down after all tests complete.
+
+#### Scenario: Server starts on default port
+- **WHEN** `spektrum --live -s tests/` is invoked
+- **THEN** an HTTP server SHALL be listening on port 7777 before any test runs
+
+#### Scenario: Server starts on custom port
+- **WHEN** `spektrum --live --live-port 9090 -s tests/` is invoked
+- **THEN** an HTTP server SHALL be listening on port 9090
+
+#### Scenario: Port conflict produces a clear error
+- **WHEN** `--live` is specified and the target port is already in use
+- **THEN** Spektrum SHALL print an error message naming the port and exit with a non-zero status code before running any tests
+
+### Requirement: Server serves the live progress page
+The HTTP server SHALL serve a self-contained HTML progress page at the root path (`/`).
+
+#### Scenario: Browser requests root path
+- **WHEN** a browser sends `GET /`
+- **THEN** the server SHALL respond with `200 OK`, `Content-Type: text/html`, and the full progress page HTML
+
+### Requirement: Server provides an SSE event stream
+The HTTP server SHALL expose a Server-Sent Events endpoint at `/events` that pushes test state changes to connected browsers.
+
+#### Scenario: Client connects to SSE endpoint
+- **WHEN** a browser sends `GET /events` with `Accept: text/event-stream`
+- **THEN** the server SHALL respond with `200 OK`, `Content-Type: text/event-stream`, and keep the connection open
+
+#### Scenario: Full state snapshot on connect
+- **WHEN** a client connects to `/events` after some tests have already run
+- **THEN** the server SHALL immediately emit a `snapshot` event containing the current state of all specs and cases
+
+#### Scenario: Live events pushed as cases change state
+- **WHEN** a test case transitions to running, passed, failed, or skipped
+- **THEN** the server SHALL push a `case-update` SSE event to all connected clients within 100ms of the transition
+
+### Requirement: Server shuts down cleanly after test run
+After all tests complete, the HTTP server SHALL remain available for a short grace period and then shut down, or shut down immediately if no clients are connected.
+
+#### Scenario: Graceful shutdown with no clients
+- **WHEN** all tests complete and no SSE clients are connected
+- **THEN** the server SHALL shut down immediately and Spektrum SHALL exit normally
+
+#### Scenario: Graceful shutdown with active clients
+- **WHEN** all tests complete and one or more SSE clients are connected
+- **THEN** the server SHALL push a `run-complete` event and then shut down within 5 seconds

--- a/openspec/specs/live-run-context/spec.md
+++ b/openspec/specs/live-run-context/spec.md
@@ -1,0 +1,49 @@
+# live-run-context Specification
+
+## Purpose
+Tell a connecting client what is being run — search path and module filter — from the
+first frame, by emitting run context before discovery begins and carrying it in every
+snapshot.
+
+## Requirements
+
+### Requirement: Runner emits run context immediately after server start
+After the live server starts, the runner SHALL emit a `run-started` event to the event queue containing the search path and optional module filter before any discovery or spec instantiation begins.
+
+#### Scenario: run-started event emitted with search path
+- **WHEN** the runner starts with `--live` and a search path
+- **THEN** a `run-started` event with `search_path` set SHALL be the first event in the queue
+
+#### Scenario: run-started event includes module filter when set
+- **WHEN** the runner starts with `--live` and a `-p module_name` filter
+- **THEN** the `run-started` event SHALL include `module_name` set to that filter value
+
+#### Scenario: run-started event emitted before spec-discovered
+- **WHEN** the runner starts with `--live`
+- **THEN** the `run-started` event SHALL appear in the queue before any `spec-discovered` event
+
+### Requirement: Live server stores run context and includes it in snapshots
+The live server SHALL store the run context from the `run-started` event and include it in every snapshot sent to connecting clients.
+
+#### Scenario: Snapshot includes run context after run-started received
+- **WHEN** a client connects after the `run-started` event has been processed
+- **THEN** the snapshot payload SHALL contain a `run_context` field with `search_path` and `module_name`
+
+#### Scenario: Snapshot run_context is null before run-started received
+- **WHEN** a client connects before the `run-started` event has been processed
+- **THEN** the snapshot payload SHALL contain `run_context: null`
+
+### Requirement: Live view displays run context in the header immediately on connect
+The live view HTML page SHALL display the search path (and module filter if present) in the header as soon as the snapshot is received, before any spec rows are rendered.
+
+#### Scenario: Search path shown in header
+- **WHEN** the browser receives a snapshot with `run_context.search_path` set
+- **THEN** the header SHALL display the search path value
+
+#### Scenario: Module filter shown alongside search path when present
+- **WHEN** the browser receives a snapshot with both `run_context.search_path` and `run_context.module_name` set
+- **THEN** the header SHALL display both the search path and the module filter
+
+#### Scenario: Header unchanged when run context absent
+- **WHEN** the browser receives a snapshot with `run_context: null`
+- **THEN** the header subtitle element SHALL remain empty

--- a/openspec/specs/live-server-linger/spec.md
+++ b/openspec/specs/live-server-linger/spec.md
@@ -1,0 +1,37 @@
+# live-server-linger Specification
+
+## Purpose
+Keep the live server accepting connections for a bounded period after a run finishes,
+so the results page is still reachable once the run itself would have exited.
+
+## Requirements
+
+### Requirement: Live server stays up after run completes
+The live progress server SHALL remain available for a configurable number of seconds after the `run-complete` event is broadcast, allowing developers time to load the results page in a browser.
+
+#### Scenario: Server stays up for linger duration
+- **WHEN** all tests complete and `--live-linger N` is set (N > 0)
+- **THEN** the live server continues accepting HTTP connections for at least N seconds before shutting down
+
+#### Scenario: Linger message printed to stdout
+- **WHEN** the live server enters its linger period
+- **THEN** a message is printed to stdout indicating how long the server will remain up (e.g., `Live view available for 5 more seconds...`)
+
+#### Scenario: Zero linger disables delay
+- **WHEN** `--live-linger 0` is passed
+- **THEN** the server shuts down immediately after broadcasting `run-complete`, matching pre-linger behavior
+
+### Requirement: CLI exposes linger flag
+The Spektrum CLI SHALL accept a `--live-linger` integer flag that specifies the post-run delay in seconds with a default of 5.
+
+#### Scenario: Default linger applied when flag omitted
+- **WHEN** `--live` is passed without `--live-linger`
+- **THEN** the server lingers for 5 seconds after the run completes
+
+#### Scenario: Custom linger value respected
+- **WHEN** `--live --live-linger 30` is passed
+- **THEN** the server lingers for 30 seconds after the run completes
+
+#### Scenario: Linger flag ignored without --live
+- **WHEN** `--live-linger N` is passed without `--live`
+- **THEN** no live server is started and the flag has no effect

--- a/openspec/specs/progress-page-ui/spec.md
+++ b/openspec/specs/progress-page-ui/spec.md
@@ -1,0 +1,71 @@
+# progress-page-ui Specification
+
+## Purpose
+What the browser renders for a live run: the spec/case hierarchy, per-case status,
+collapsible results, SSE reconnection, and the completion banner.
+
+## Requirements
+
+### Requirement: Page displays the full spec/case hierarchy
+The progress page SHALL render all discovered specs and their cases in a tree structure that mirrors the final pretty-print output, grouped by spec class name.
+
+#### Scenario: Hierarchy shown on page load
+- **WHEN** the page is loaded and a snapshot event has been received
+- **THEN** each spec SHALL be shown as a top-level section with its cases listed beneath it
+
+#### Scenario: Nested specs shown at correct depth
+- **WHEN** a spec contains nested child specs
+- **THEN** child specs SHALL be indented under their parent spec
+
+### Requirement: Running cases show a "running" status indicator
+Any test case currently executing SHALL be visually marked with a "running" status badge.
+
+#### Scenario: Case transitions to running
+- **WHEN** a `case-update` event with status `running` is received for a case
+- **THEN** that case SHALL display a "running" badge (e.g., spinner or distinct color) within one render cycle
+
+### Requirement: Pending cases show a "pending" status indicator
+Any test case that has not yet started SHALL be visually marked as "pending".
+
+#### Scenario: Initial page render shows pending cases
+- **WHEN** the page first renders cases from the snapshot
+- **THEN** all cases that have not yet started SHALL display a "pending" badge
+
+#### Scenario: Case remains pending until it starts
+- **WHEN** other cases in the same spec are running or complete
+- **THEN** cases that have not yet started SHALL continue to show "pending"
+
+### Requirement: Completed cases show result in a collapsible dropdown
+Each completed case (passed, failed, or skipped) SHALL display its result status and offer a collapsible section containing result details.
+
+#### Scenario: Passed case shows pass badge
+- **WHEN** a `case-update` event with status `passed` is received
+- **THEN** that case SHALL display a "passed" badge (e.g., green)
+
+#### Scenario: Failed case shows fail badge and expandable details
+- **WHEN** a `case-update` event with status `failed` is received
+- **THEN** that case SHALL display a "failed" badge (e.g., red) and a collapsed dropdown
+- **THEN** expanding the dropdown SHALL reveal the failure message and traceback
+
+#### Scenario: Skipped case shows skip badge
+- **WHEN** a `case-update` event with status `skipped` is received
+- **THEN** that case SHALL display a "skipped" badge and the skip reason in the collapsed dropdown
+
+#### Scenario: Passed case dropdown shows expect results
+- **WHEN** a passed case's dropdown is expanded
+- **THEN** it SHALL show the list of `expect()` assertion results for that case
+
+### Requirement: Page reconnects automatically if the SSE stream drops
+If the SSE connection to the server is lost, the page SHALL attempt to reconnect automatically.
+
+#### Scenario: Reconnection after disconnect
+- **WHEN** the SSE connection is lost (network hiccup or server restart)
+- **THEN** the browser SHALL attempt to reconnect within 3 seconds using the browser's built-in EventSource retry
+
+### Requirement: Page shows a completion banner when all tests finish
+When a `run-complete` event is received, the page SHALL display a summary banner with total pass/fail/skip counts.
+
+#### Scenario: Run complete banner appears
+- **WHEN** a `run-complete` SSE event is received
+- **THEN** the page SHALL display a banner with the counts of passed, failed, and skipped cases
+- **THEN** the page title SHALL update to reflect the final result (e.g., "✓ All passed" or "✗ 3 failed")

--- a/openspec/specs/test-runner-lifecycle/spec.md
+++ b/openspec/specs/test-runner-lifecycle/spec.md
@@ -1,0 +1,36 @@
+# test-runner-lifecycle Specification
+
+## Purpose
+How `SpektrumRunner` reports its own progress to the live event queue — accepting the
+queue, announcing each discovered spec before execution, and signalling completion.
+
+## Requirements
+
+### Requirement: Runner accepts a live-event queue
+When a live event queue is provided to `SpektrumRunner`, the runner SHALL publish lifecycle events to it without affecting normal execution behavior.
+
+#### Scenario: No queue provided — no change in behavior
+- **WHEN** `SpektrumRunner` is used without `--live`
+- **THEN** no events SHALL be published and test execution SHALL behave identically to before
+
+#### Scenario: Queue provided — case-started event emitted
+- **WHEN** a live queue is configured and a test case begins execution
+- **THEN** the runner SHALL put a `case-started` event on the queue containing the spec name, case name, and timestamp
+
+#### Scenario: Queue provided — case-finished event emitted
+- **WHEN** a live queue is configured and a test case finishes execution
+- **THEN** the runner SHALL put a `case-finished` event on the queue containing spec name, case name, status (passed/failed/skipped), duration, and result details (failure message + traceback if failed; skip reason if skipped; expect results if passed)
+
+### Requirement: Runner emits a spec-discovered event for each spec before execution
+When a live queue is provided, the runner SHALL publish a `spec-discovered` event for every spec and case at discovery time, before any test runs.
+
+#### Scenario: All specs and cases announced before first test
+- **WHEN** a live queue is configured and discovery completes
+- **THEN** the runner SHALL emit one `spec-discovered` event per spec containing the spec's full case list, before any `case-started` event is emitted
+
+### Requirement: Runner emits a run-complete event after all tests finish
+When a live queue is provided, the runner SHALL publish a `run-complete` event after all specs and cases have finished executing.
+
+#### Scenario: Run-complete event contains summary counts
+- **WHEN** all tests finish
+- **THEN** the runner SHALL emit a `run-complete` event with totals: passed count, failed count, skipped count, and total duration


### PR DESCRIPTION
**Issue:** [MQ-3301](https://liquidweb.atlassian.net/browse/MQ-3301)

## Why

Spektrum had no agent-facing documentation and a half-finished OpenSpec directory:
`openspec/` held empty `specs/` and `changes/` trees but no `project.md` or `config.yaml`,
so the tooling could not operate on this repo. `.claude/` held only local settings, and
there was no `AGENTS.md`. An agent moving from a sibling repo into Spektrum lost every
convention it had been following.

## What

- `openspec/config.yaml` + `openspec/project.md` — the working agreement: red-then-green,
  both test suites, lint, scope discipline, one-commit-per-PR, and the reporter
  compatibility contract.
- `AGENTS.md`, with `CLAUDE.md` symlinked to it — architecture, file map, commands, and the
  reasoning behind non-obvious choices.
- `.claude/conventions.md` — Python standards, scoped to new and modified code so they do
  not read as a mandate to reformat the existing tree.
- `CONTRIBUTING.md` and `.github/pull_request_template.md` — the repo had neither.
- `README.rst` — the two empty section headings are filled, plus a "Selecting what runs"
  section covering `-p`, `-t` and `-m`.
- `openspec/specs/` — six capability specs, back-filled from the live-view work that
  shipped in v1.3.0, whose OpenSpec artifacts had only ever existed on a feature branch.
- `openspec/changes/` — the `add-agent-docs` record, four archived changes, and a proposal
  for the follow-up work.

### Blast radius

Documentation and repository tooling only. **No file under `spektrum/` or `tests/` is
touched**, no version bump, no release-note entry — nothing reaches users of the library.

## Reading guide

| File | What to look at | Why |
|---|---|---|
| `openspec/project.md` | The PR procedure | This is what future changes are held to |
| `AGENTS.md` | "Two suites, and neither runs the other" | The correction most likely to surprise a reviewer |
| `openspec/specs/` | Six promoted specs | Requirements for behaviour that already shipped, not new behaviour |
| `.claude/conventions.md` | The scoping sentence | Deliberately not a reformatting mandate |

## Corrections found by reviewing the docs against the code

The first draft of these documents made six claims that do not hold. Each was checked
against the source:

- **`can_*` is not a case-naming convention.** `case_filter` in `spec.py` collects every
  public non-lifecycle method; `grep -rn 'def can_'` over the tree returns nothing.
- **`tests/` is not pytest-only.** `tests/live/` is 22 cases across 7 `Spec` classes, run by
  the CLI. `pytest tests -q` collects none of them and reports success regardless, so the
  whole-suite gate in `project.md` now runs both.
- **Bare `tox` runs nothing.** `envlist` is py36–py39 + pypy3 while CI tests only 3.12, so
  it fails on absent interpreters. `tox -e py312` / `tox -e flake8` are named instead.
- **The report does not reach "each enabled reporter."** It reaches the console renderer,
  and xunit only with `--xunit-results`. TestRail is driven per-case during the run and the
  live view from an event queue; neither sees `build_report()`.
- **`_add_expect_to_spec()` is called by `require()` too**, not only `expect()`.
- **Nested classes become child specs only if they subclass `Spec`.** A nested plain class
  raises `AttributeError` in `spec_filter`, which is recorded as a known sharp edge.

The file map also listed `tests/reporting/`, which does not exist on this branch, and
omitted `docs/` and `tools/` entirely.

## Public-repository audit

The back-filled linger spec required a downstream harness to forward `--live-linger`. That
requirement is dropped: a consumer's obligation is not Spektrum's to specify, it cannot be
verified here, and this repository is public. Remaining references in the archived
proposal, design, tasks and delta are generalised. Every added document and every commit
message on the branch was grepped for internal product names, private hostnames and
tracker URLs.

## Test plan

**Red-then-green:** not applicable — no behavioural change. Counts are unchanged from
`master` by construction, since the branch touches no code.

- `python -m pytest tests -q` → **1 passed**
- `python -m spektrum -s tests/live/` → **22 passed, 121 expectations**
- `python -m flake8 spektrum tests` → **exit 0**
- `openspec validate --all` → **8 passed, 0 failed**
- Every command in the README's new section was executed against a throwaway spec tree.
  That surfaced two silent-failure semantics now documented: `-p "re:..."` is anchored at
  the end only (`re.search(f'{pattern}$', ...)`), while `-t "re:..."` is anchored at both
  ends and is also matched against the spaced form of the case name.
- `README.rst` renders through docutils with no warnings.

## Known and deferred

Three defects are documented rather than fixed; each changes behaviour and so needs its own
change with a real spec:

1. `--tr-endpoint` defaults to a private TestRail tenant, so a contributor who passes
   `--tr-username`/`--tr-apikey` without it sends their own credentials to someone else's
   host. Already public on `master` and in every shipped 1.x wheel.
2. `spec_filter` raises `AttributeError` on a nested non-`Spec` class.
3. `-p`/`-t` help text never mentions the `re:` prefix, making the feature undiscoverable
   outside the source.

## Checklist

- [x] `python -m pytest tests -q` — 1 passed
- [x] `python -m spektrum -s tests/live/` — 22 passed, 121 expectations
- [x] `tox -e flake8` clean
- [x] Docs updated (`README.rst` / `AGENTS.md` / `docs/`)
- [x] Squashed to a single commit
- [x] No version bump — this PR is not a release
- [x] No secrets, tokens, or real customer data included


[MQ-3301]: https://liquidweb.atlassian.net/browse/MQ-3301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ