### PR TITLE
MQ-3303: stop TestRail sections being created for deselected specs

### DIFF
--- a/spektrum/reporting/testrail.py
+++ b/spektrum/reporting/testrail.py
@@ -58,6 +58,9 @@ class TestRailRenderer(object):
 
         spec = TestRailSpecData(spec)
 
+        if not _has_selected_cases(spec):
+            return
+
         tr_section = next(
             (section for section in (sections or []) if section['name'] == spec.name),
             None
@@ -365,6 +368,19 @@ class TestRailClient(object):
             params=parameters,
             timeout=30
         )
+
+
+def _has_selected_cases(spec):
+    '''Whether `spec` or any of its descendants has a case surviving selection.
+
+    `filter_cases_by_data` only trims each spec's own `__test_cases__`; it never
+    removes a spec from its parent's children. Without this check,
+    `reconcile_spec_and_section` would create a TestRail section for every spec
+    discovered under the search path, regardless of `--select-by-metadata` /
+    `--select-tests` / `--exclude-by-metadata`, flooding the suite with sections
+    that have no cases in them.
+    '''
+    return bool(spec.cases) or any(_has_selected_cases(child) for child in spec.specs)
 
 
 def restructure(sections, level=0, structured=None):

--- a/tests/reporting/test_testrail.py
+++ b/tests/reporting/test_testrail.py
@@ -1,0 +1,80 @@
+from unittest import mock
+
+from spektrum import Spec, metadata
+from spektrum.reporting.testrail import TestRailRenderer
+
+
+class LeafWithMatchingCase(Spec):
+    @metadata(regression=True)
+    def can_run_under_regression(self):
+        pass
+
+    def can_run_with_no_metadata(self):
+        pass
+
+
+class LeafWithoutMatchingCase(Spec):
+    def can_run_with_no_metadata(self):
+        pass
+
+
+class RootSpec(Spec):
+    class Selected(LeafWithMatchingCase):
+        pass
+
+    class Unselected(LeafWithoutMatchingCase):
+        pass
+
+
+def _make_renderer():
+    renderer = TestRailRenderer.__new__(TestRailRenderer)
+    renderer.project = 1
+    renderer.suite = 1
+    renderer.specs = {}
+    renderer.tr = mock.Mock()
+    renderer.tr.add_section.return_value = mock.Mock(
+        json=mock.Mock(return_value={'id': 111, 'suite_id': 1})
+    )
+    return renderer
+
+
+def _created_section_names(renderer):
+    return [call.kwargs['name'] for call in renderer.tr.add_section.call_args_list]
+
+
+def test_reconcile_skips_sections_with_no_selected_cases():
+    renderer = _make_renderer()
+    root = RootSpec()
+
+    renderer.reconcile_spec_and_section(
+        root,
+        metadata={'regression': True},
+        test_names=None,
+        exclude=None,
+        sections=[],
+    )
+
+    created = _created_section_names(renderer)
+
+    assert 'Root Spec' in created
+    assert 'Selected' in created
+    assert 'Unselected' not in created
+
+
+def test_reconcile_creates_all_sections_with_no_filter():
+    renderer = _make_renderer()
+    root = RootSpec()
+
+    renderer.reconcile_spec_and_section(
+        root,
+        metadata=None,
+        test_names=None,
+        exclude=None,
+        sections=[],
+    )
+
+    created = _created_section_names(renderer)
+
+    assert 'Root Spec' in created
+    assert 'Selected' in created
+    assert 'Unselected' in created


### PR DESCRIPTION
**Issue:** [MQ-3303](https://liquidweb.atlassian.net/browse/MQ-3303)

## Why

A narrowed run still creates a TestRail section for **every spec discovered under the
search path**, including specs whose cases were all filtered out. Scoping a run with
`--select-by-metadata`, `--select-tests` or `--exclude-by-metadata` floods the suite with
empty sections — and TestRail keeps them, so every narrowed run leaves more behind in a
shared suite.

## What

`filter_cases_by_data()` only trims each spec's own `__test_cases__`. It never removes a
spec from its parent's `specs` list, so after filtering the tree still has its
discovery-time shape with some nodes holding zero cases, and `reconcile_spec_and_section`
walks all of it.

- Guard the reconcile with `_has_selected_cases(spec)`.
- Recurse into child specs, so a parent whose own cases were all filtered out is still kept
  when a descendant has a surviving case. Without the recursion the guard would prune the
  path to the selected tests.

### Blast radius

`reporting/testrail.py` only. It is worth noting this is the one reporter reached
**per-case during a run** rather than from the final report, and the only one that writes
to a system outside the run — so its mistakes outlive the process instead of merely
spoiling a summary. No other reporter, the runner, and the public API are untouched.

## Reading guide

| File | What to look at | Why |
|---|---|---|
| `spektrum/reporting/testrail.py` | `_has_selected_cases` and its call site | The recursion is the part that matters — a non-recursive guard passes the first test and breaks nested selection |
| `tests/reporting/test_testrail.py` | Both tests together | The control is what stops the guard being satisfied by suppressing everything |

## Test plan

**Red-then-green** — source file reverted to `master` with the new tests kept:

- Failing without the change: **1 failed, 2 passed**
- Passing with the change: **3 passed**

The total is 3, not the 175 reported on the MQ-3300 branch, because this branch is cut from
`master`, which does not carry that branch's `tests/test_expect_source.py`.

**Automated tests added:**
- [x] `test_reconcile_skips_sections_with_no_selected_cases` — the deselected section is not
      created, while the root and the matching child still are
- [x] `test_reconcile_creates_all_sections_with_no_filter` — the control: with no filter,
      every section is still created

**Also run:**
- `python -m spektrum -s tests/live/` — 22 passed, 121 expectations
- `python -m flake8 spektrum tests` — exit 0

## Checklist

- [x] `python -m pytest tests -q` — 3 passed (RED was 1 failed, 2 passed)
- [x] `python -m spektrum -s tests/live/` — 22 passed, 121 expectations
- [x] `tox -e flake8` clean
- [x] Docs updated — n/a, no user-facing behaviour or flag changes
- [x] Squashed to a single commit
- [x] No version bump — this PR is not a release
- [x] No secrets, tokens, or real customer data included


[MQ-3303]: https://liquidweb.atlassian.net/browse/MQ-3303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ