### PR TITLE
MQ-3307: define the release process and release 1.3.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0
+current_version = 1.3.1
 commit = True
 tag = True
 

--- a/.claude/skills/cut-a-release/SKILL.md
+++ b/.claude/skills/cut-a-release/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: cut-a-release
+description: Cut, prepare or publish a Spektrum release to PyPI. Use when asked to "cut a release", "ship a version", "do a release", "release 1.4.0", "bump the version", "is there anything to release", or "publish to PyPI". Drives tools/release.sh; never reproduces the release steps by hand.
+---
+
+# Cutting a Spektrum release
+
+`tools/release.sh` is the release process. **Drive it. Do not reimplement it, and do not
+work around anything it refuses.**
+
+Publishing is one act: pushing a tag to `liquidweb/Spektrum` makes Travis upload to PyPI.
+Merging does not publish. Running `bumpversion` does not publish. Two versions — 1.2.2 and
+1.3.0 — reached `master` and never reached PyPI because their tags were created on a
+pre-merge commit and pushed to a personal fork. Every guard in that script exists because
+of one of those two mistakes.
+
+## What to do
+
+Run it and read what it says:
+
+```shell
+./tools/release.sh
+```
+
+With no arguments it works out which state the repository is in and does the next right
+thing — nothing to release, changes waiting, a release PR already open, or a release that
+merged but was never tagged. It is interactive; it will ask before it changes anything.
+
+The subcommands exist for when you already know the state:
+
+| Command | What it does |
+|---|---|
+| `./tools/release.sh status` | read-only: what is published, what has drifted |
+| `./tools/release.sh release <major\|minor\|patch>` | notes + bump + one commit + PR |
+| `./tools/release.sh publish` | tags the merged master and pushes — **this publishes** |
+
+## Your job, and the parts that are not your job
+
+**Yours:** proposing the version part. Read the entries under `Next Release` in
+`docs/release_notes/index.rst` and say whether they look like a patch, a minor or a major,
+*with your reasoning*, then let the user decide. Bug fixes are a patch; a new flag or
+capability is a minor; a change that breaks a consumer's suite is a major. The script
+deliberately does not guess this.
+
+**Also yours:** reporting what happened. Surface the PR link. If the script refuses, show
+the refusal — it names the fix.
+
+**Not yours:** anything the script does. Do not edit version files, do not create tags, do
+not hand-write the release notes rename, do not push a tag because the script would not.
+A refusal is an answer, not an obstacle.
+
+## Two commands, not one, and why
+
+`release` opens a PR and stops. `publish` tags the merge commit afterwards. They are
+separate because the commit worth tagging does not exist until the PR merges — tagging
+before that is the exact failure that lost both previous releases.
+
+So a release spans a review. Expect to do this in two sittings, and say so rather than
+waiting or inventing a way around it.
+
+When the user answers "yes, it merged", `publish` re-reads the version, the notes and the
+version files from the canonical `master` and refuses if the bump is not actually there.
+A wrong answer costs a refusal, not a bad tag. Do not try to verify the merge yourself
+first — that check is already in the script and is the authoritative one.
+
+## Before the release
+
+Every merged PR is supposed to add its own entry under `Next Release`. If that section is
+empty, `release` refuses, and the fix is a normal PR adding the entries — not editing the
+notes as part of the release. Say that rather than filling them in yourself: whoever made
+the change knows what it meant.
+
+## When PyPI does not update
+
+The tag is pushed and the release is in flight; nothing is lost. The build is at
+https://app.travis-ci.com/github/liquidweb/Spektrum/builds and a dead credential shows
+there as a failing deploy step on an otherwise green build. `PYPI_TOKEN` is a Travis
+repository secret, rotatable by anyone with admin on the repo. See
+[docs/maintenance/index.rst](../../../docs/maintenance/index.rst).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,9 @@ Not derivable at a glance, and easy to get wrong:
 │   ├── specs/             # capability baseline (the six live-view capabilities)
 │   └── changes/           # in-flight proposals, plus archive/ of completed ones
 ├── tools/run_tests.sh     # stale — calls nosetests; use the commands below instead
-├── .claude/conventions.md # Python standards
+├── .claude/
+│   ├── conventions.md     # Python standards
+│   └── skills/cut-a-release/  # "let's cut a new release" -> tools/release.sh
 ├── tox.ini                # pytest+coverage envs, the flake8 env, and the flake8 config
 └── setup.py               # version lives here and in .bumpversion.cfg
 ```
@@ -179,9 +181,25 @@ py36–py39 + pypy3, and CI tests only 3.12. Treat **3.12 as the supported versi
 the only one actually exercised — and don't take the other two as constraints without
 asking.
 
-Releasing is `bumpversion`, which updates `setup.py` and `docs/conf.py` together, commits,
-and tags. The tag is what publishes to PyPI from CI, so a version bump in an ordinary PR
-ships a release by accident.
+**Pushing a tag to `liquidweb/Spektrum` is the release.** Travis builds every tag and
+uploads to PyPI (`deploy.on.tags: true` in `.travis.yml`). Nothing else publishes — not
+merging to `master`, not running `bumpversion`. The inverse worry is the one to drop: a
+version bump merged in an ordinary PR ships nothing at all, which is exactly how 1.2.2 and
+1.3.0 came to sit on `master` having never reached PyPI.
+
+Use `tools/release.sh`. Run it with no arguments and it detects the state and does the
+next right thing; `status`, `release <part>` and `publish` are there when you already know
+it. In a session, "let's cut a new release" reaches it through
+[.claude/skills/cut-a-release/](.claude/skills/cut-a-release/SKILL.md) — drive the script,
+never reproduce its steps. It refuses rather than warns.
+
+Every PR adds its own entry under `Next Release` in `docs/release_notes/index.rst`. The
+release renames that section to the version it becomes; an empty one is refused.
+
+The two traps the script exists to close: `bumpversion` tags the commit it runs on, which
+on a branch is the pre-merge commit the merge then rewrites; and `git push origin --tags`
+sends the tag to a personal fork that CI does not watch. Full process:
+[docs/maintenance/index.rst](docs/maintenance/index.rst).
 
 ## See also
 

--- a/README.rst
+++ b/README.rst
@@ -98,9 +98,23 @@ See the `contributing guide
 <https://github.com/liquidweb/spektrum/blob/master/CONTRIBUTING.md>`_ for setup, the test
 suites, and what a change needs to prove before review.
 
-Release Notes
-~~~~~~~~~~~~~~
+Releases
+~~~~~~~~~
 
-- `Release notes
-  <https://github.com/liquidweb/spektrum/blob/master/docs/release_notes/index.rst>`__ are
-  available in the documentation
+Spektrum is published to PyPI at https://pypi.org/project/Spektrum/::
+
+    pip install spektrum
+
+Releases are cut every week or two, and only when something has merged — a quiet fortnight
+produces no release.
+
+`Release notes
+<https://github.com/liquidweb/spektrum/blob/master/docs/release_notes/index.rst>`__ live in
+the documentation. The section at the top, ``Next Release``, is the accumulating draft of
+the next version: **if your PR changes behaviour, add your entry there as part of it.** The
+release renames that section to the version it becomes, so the note written at review time
+is the note that ships.
+
+Maintainers: the procedure is in `docs/maintenance/index.rst
+<https://github.com/liquidweb/spektrum/blob/master/docs/maintenance/index.rst>`__, and
+``./tools/release.sh`` runs it.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,8 +31,8 @@ copyright = u'2021, LiquidWeb'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 
-version = '1.3.0'
-release = '1.3.0'
+version = '1.3.1'
+release = '1.3.1'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/maintenance/index.rst
+++ b/docs/maintenance/index.rst
@@ -8,44 +8,165 @@ These notes are directed towards helping with the maintenance of the
 Spektrum project.
 
 Releasing a new version of Spektrum
-----------------------------------
+-----------------------------------
 
-#. Start with a fresh local branch.
+**Pushing a tag to** ``liquidweb/Spektrum`` **is the release.** Nothing else
+publishes. Travis builds every tag and uploads the result to PyPI; merging to
+``master`` does not, and neither does running ``bumpversion``. A version bump
+sitting on ``master`` with no tag is not a release — it is the state this
+repository was in for two versions.
 
-   .. code-block:: shell
+Both of those are still on PyPI's missing list:
 
-        git checkout -b prep_for_release
+===========  ==================  ======================================
+Version      Reached PyPI        Why not
+===========  ==================  ======================================
+1.2.2        no                  tag left on an unmerged commit, pushed
+                                 to a personal fork
+1.3.0        no                  same
+===========  ==================  ======================================
 
-#. Update and commit release notes in ``docs/release_notes/index.rst``.
-#. Execute bumpversion.
+Two mistakes produced both, and they are easy to repeat by hand:
 
-   .. code-block:: shell
+#. ``bumpversion`` tags the commit it is run on. On a branch, that is the
+   pre-merge commit — and the merge rewrites it, so the tag is left pointing
+   at a commit that never reaches ``master``.
+#. ``git push origin --tags`` sends the tag to whatever ``origin`` is. For
+   both maintainers ``origin`` is a personal fork. Travis watches
+   ``liquidweb/Spektrum``, so it never sees the tag and never builds.
 
-        # Available parts: major, minor, patch
-        bumpversion <part>
+Notes are written as you go
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. Push up branch and tag
+``docs/release_notes/index.rst`` opens with a ``Next Release`` section. **Every
+PR adds its own entry there**, in the PR that makes the change, while the person
+writing it still knows what it meant. The release then renames that section to
+the version it becomes.
 
-   .. code-block:: shell
+A release with an empty ``Next Release`` is refused. Reconstructing months of
+notes from ``git log`` at release time is how the log came to stop at 1.0.0
+while ``setup.py`` said 1.3.0.
 
-        git push origin prep_for_release --tags
+Use the script
+^^^^^^^^^^^^^^
 
-#. Create PR.
-#. Wait for CI to pass and PR to merge.
-#. Remove old packages
+``tools/release.sh`` exists so that neither mistake above is reachable. It
+refuses rather than warns, and it always names the fix. Run it with no
+arguments and it works out what is needed:
 
-   .. code-block:: shell
+.. code-block:: shell
 
-        rm -r dist
+     ./tools/release.sh
 
-#. Build sdist and wheel
+It reports which state the repository is in and does the next right thing:
 
-   .. code-block:: shell
+===============================  =========================================
+State                            What happens
+===============================  =========================================
+Nothing merged since the tag     Says so and exits. Not every fortnight
+                                 produces a release.
+Changes waiting                  Lists them, shows the candidate versions,
+                                 asks for major/minor/patch, then releases.
+``Next Release`` empty           Refuses. The merged changes never said
+                                 what they changed.
+A release PR already open        Tells you what to merge.
+Merged but never tagged          Goes straight to tagging. This is the
+                                 state that lost 1.2.2 and 1.3.0.
+===============================  =========================================
 
-        python setup.py sdist
-        python setup.py bdist_wheel
-#. Upload to PyPI
+In a Claude Code session, "let's cut a new release" reaches the same script
+through ``.claude/skills/cut-a-release/``.
 
-   .. code-block:: shell
+The subcommands are there for when you already know the state:
 
-        twine upload dist/*
+.. code-block:: shell
+
+     ./tools/release.sh status                    # read-only drift report
+     ./tools/release.sh release patch             # or: minor, major
+     ./tools/release.sh publish                   # this is what publishes
+
+**Phase 1 — release.** Cuts a branch named ``v<old>-to-v<new>``, renames
+``Next Release`` to ``Release: <new>`` and opens a fresh empty one, bumps the
+version, runs both suites and lint, makes **one** commit with the subject
+``v<old> -> v<new>``, pushes to your fork and opens the PR. The subject is what
+makes published versions visible in ``git log --oneline``.
+
+No tag is created in this phase, and that is deliberate. There is nothing to
+tag until the PR merges.
+
+**Phase 2 — publish.** Run once that PR has merged:
+
+.. code-block:: shell
+
+     ./tools/release.sh publish
+
+It reads the version from the canonical ``master`` rather than from your
+checkout, checks the version files agree with each other and with the notes,
+checks the version is not already on PyPI, asks you to type the version to
+confirm, then tags the merge commit and pushes that tag to the canonical
+remote. It then waits for the version to appear on PyPI and tells you where
+the build is if it does not.
+
+What the script checks
+^^^^^^^^^^^^^^^^^^^^^^
+
+Each of these refuses the release outright:
+
+* No remote points at ``liquidweb/Spektrum``, or more than one does. The
+  script never assumes a remote is called ``upstream``.
+* The working tree is dirty when the branch is cut.
+* ``docs/release_notes/index.rst`` has no section for the new version.
+* ``setup.py``, ``docs/conf.py`` and ``.bumpversion.cfg`` disagree.
+* The tag already exists — locally on a different commit, or on the remote.
+* The version is already on PyPI. Versions there cannot be reused or
+  replaced, ever.
+* Either test suite fails, or flake8 does.
+
+Doing it by hand
+^^^^^^^^^^^^^^^^
+
+If the script cannot run, the process it encodes is:
+
+.. code-block:: shell
+
+     # Phase 1, on a branch off the canonical master
+     git fetch upstream
+     git checkout -b v1.3.1-to-v1.3.2 upstream/master
+     # rename the "Next Release" heading to "Release: 1.3.2" and open a
+     # fresh empty "Next Release" above it, then:
+     bumpversion --allow-dirty --no-commit --no-tag patch
+     python -m pytest tests -q
+     python -m spektrum -s tests/live/
+     python -m flake8 spektrum tests
+     git add docs/release_notes/index.rst setup.py docs/conf.py .bumpversion.cfg
+     git commit -m 'v1.3.1 -> v1.3.2'
+     # push to your fork, open the PR, get it merged
+
+     # Phase 2, after the merge
+     git fetch upstream
+     git tag -a v<version> upstream/master -m 'v<version>'
+     git push upstream v<version>          # upstream, never origin
+
+The ``--no-commit --no-tag`` and the ``upstream/master`` in ``git tag`` are
+the whole point. Dropping either reproduces 1.2.2 and 1.3.0.
+
+Then confirm it actually published — a pushed tag is not proof:
+
+.. code-block:: shell
+
+     ./tools/release.sh status
+
+If the version has not appeared, the build is at
+https://app.travis-ci.com/github/liquidweb/Spektrum/builds. A dead credential
+surfaces there as a failing deploy step on an otherwise green build.
+
+The credential is a ``PYPI_TOKEN`` secret in Travis repository settings:
+
+     https://app.travis-ci.com/github/liquidweb/Spektrum/settings
+
+Travis mirrors GitHub repository permissions, so anyone with admin on
+``liquidweb/Spektrum`` can read and replace it there. It was last exercised on
+2025-06-11, so treat a deploy that fails on authentication as "rotate the
+token", not as a mystery. Replacing it needs a PyPI account with maintainer
+rights on the Spektrum project — worth confirming who holds that *before* a
+release depends on it.

--- a/docs/release_notes/index.rst
+++ b/docs/release_notes/index.rst
@@ -4,6 +4,60 @@
 Release Notes
 =================
 
+Next Release
+--------------------------------
+
+*Nothing yet.*
+
+Release: 1.3.1
+--------------------------------
+
+Features and bug fixes
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+ #. Fixing crash where a run that completed every test lost its entire
+    report at render time, whenever the source expression behind an
+    assertion could not be resolved to an expect(X).to.matcher(Y) call -
+    gh-#15
+ #. Fixing assertion output falling back to the label None instead of the
+    value when the source expression is unavailable - gh-#15
+ #. Fixing TestRail sections being created for specs whose cases were all
+    deselected, leaving empty sections in a shared suite after a run
+    narrowed by --select-by-metadata, --select-tests or
+    --exclude-by-metadata - gh-#17
+ #. Adding contributor and agent documentation - AGENTS.md, CONTRIBUTING.md
+    and a pull request template - and documenting test selection with -p,
+    -t and -m in the README - gh-#16
+ #. Defining the release process - tools/release.sh runs it, interactively
+    when given no arguments, and docs/maintenance/index.rst documents it. The
+    instructions it replaces produced version tags that never reached PyPI,
+    which is why 1.2.2 and 1.3.0 were never published. Release notes now
+    accumulate under a Next Release section as each change merges, rather than
+    being reconstructed at release time - gh-#18
+
+Release: 1.3.0
+--------------------------------
+
+Features and bug fixes
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+ #. Adding a live progress view - --live starts an HTTP server for the
+    duration of the run, with --live-port to choose the port (default 7777)
+    and --live-linger to hold the server open once the run finishes
+    (default 5 seconds) - gh-#14
+ #. Streaming spec discovery, case results and individual assertions to the
+    live view as the run progresses, rather than only at the end - gh-#14
+ #. Fixing assertion output for f-string targets, which rendered the
+    unevaluated placeholder text and unicode escapes instead of the
+    evaluated value - gh-#14
+ #. Fixing TestRail results being dropped for any case missing from the
+    section cache - the case is now created at report time and titled from
+    the spaced form of the method name - gh-#13, gh-#14
+ #. Narrowing the exception handling around expect source lookup, which
+    caught bare Exception and re-raised failures as Exception; it now
+    catches the specific errors it can recover from and raises RuntimeError
+    - gh-#14
+
 Release: 1.0.0
 --------------------------------
 

--- a/openspec/changes/enforce-release-notes-and-cadence/.openspec.yaml
+++ b/openspec/changes/enforce-release-notes-and-cadence/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-28
+skip_specs: true

--- a/openspec/changes/enforce-release-notes-and-cadence/design.md
+++ b/openspec/changes/enforce-release-notes-and-cadence/design.md
@@ -1,0 +1,177 @@
+## Context
+
+See proposal.md — Why. Three constraints shape the approach.
+
+MQ-3307 is a prerequisite: it introduces `tools/release.sh`, the corrected release
+documentation and the 1.3.1 bump, and this change reshapes that script rather than
+creating it. Its central property — a tag exists only
+on a commit already on `master` — is load-bearing here, and is why `release` and `publish`
+stay separate commands rather than collapsing into the one the request describes.
+
+Travis already builds `pull_request` events (builds #74–#80), so the gate needs a `tox`
+environment and one matrix entry, not new infrastructure. Its deploy block holds
+`PYPI_TOKEN` and nothing else, and this change adds no credential to it: storing push
+rights for the canonical repository in CI widens what a compromised build can reach, for
+a step a maintainer runs in seconds.
+
+`docs/release_notes/index.rst` is Sphinx source, reached from `README.rst` and
+`docs/index.rst`. Whatever the gate reads has to keep rendering.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A contributor learns a note is expected at the moment they can still write a good one,
+  from the build rather than from a reviewer's memory.
+- A reader of `git log --oneline` can see where each published version starts.
+- The gate runs identically on a laptop and in CI — a check only reproducible in CI is a
+  check people cannot fix before pushing.
+- The release becomes clerical. Nothing in it should require remembering what a change
+  three weeks ago was for.
+
+**Non-Goals:**
+
+- Blocking a release on the cadence. One to two weeks is a habit, not a rule; a fortnight
+  with nothing merged should produce no release and no noise.
+- Guaranteeing note *quality*. The gate can prove a line exists. Only review can say it
+  describes what a consumer will notice.
+- Any second source of truth. No `CHANGELOG.md` — the Sphinx notes are what the README
+  links to and what gets published.
+
+## Decisions
+
+**`Next Release` lives at the top of `docs/release_notes/index.rst`, not in a new file.**
+A `CHANGELOG.md` would be the third place a version is written down, after `setup.py` and
+`docs/conf.py`, and the one nothing renders. Keeping the draft in the same file as the
+history means `release` is a rename rather than a migration, and the notes a contributor
+writes are the notes that publish.
+
+When empty the section carries a `*Nothing yet.*` placeholder, so Sphinx does not render a
+bare heading and so "is there anything to release" is answerable by reading the file.
+
+**The gate is Python (`tools/check_release_notes.py`), not shell.** It parses RST
+structure and diffs two revisions of it; that is beyond what is comfortable in `awk`, and
+unlike `release.sh` it wants unit tests of its own. Running it through a `tox -e notes`
+environment gives contributors the identical command CI runs.
+
+**The gate compares entry counts, not file modification.** It extracts the `Next Release`
+body from the base and from the head and requires strictly more `#.` items in the head.
+Alternatives rejected: *requiring the file to be touched* passes on a whitespace edit;
+*requiring the entry to name the PR number* is unwritable, since the number does not exist
+until the PR is opened.
+
+**The gate fires only on `spektrum/`, excluding `spektrum/vendor/`.** Tests, docs,
+`openspec/`, `tools/` and CI config are exempt. A rule that fires on documentation PRs
+teaches people to route around it, and `spektrum/vendor/*` is excluded from flake8 for the
+same reason it is excluded here — it is not ours to describe.
+
+**There is a deliberate escape hatch: a `No-release-note: <reason>` trailer** in the head
+commit. Some `spektrum/` changes genuinely have no consumer-visible effect. A hard gate
+with no exit gets switched off the first time it is wrong, and a trailer is visible in
+review, which a CI override flag is not.
+
+**The base revision is resolved, never assumed.** On Travis, `TRAVIS_BRANCH` is the base
+branch of a PR build and the clone is shallow, so the script fetches the base explicitly
+before diffing. Locally it defaults to the merge-base with the canonical remote's `master`,
+resolved by URL exactly as `release.sh` does. `--base <ref>` overrides both.
+
+**Bare `tools/release.sh` detects state rather than running a fixed sequence.** A linear
+wizard assumes you are at the start; the interesting failures happen when you are not.
+Five states, distinguished from the canonical `master`, PyPI and the notes:
+
+| State | Signal | What it does |
+|---|---|---|
+| Nothing to release | no commits since the released tag | exits saying so |
+| Changes waiting | commits merged, `Next Release` non-empty | shows them, asks the part |
+| Notes missing | commits merged, `Next Release` empty | refuses; names the PRs owing a note |
+| Release PR open | a `v*-to-v*` branch exists, master unchanged | says what to merge |
+| **Merged, never tagged** | master's version > PyPI's, notes cover it | goes straight to tagging |
+
+The last row is the whole point. It is the state that lost 1.2.2 and 1.3.0, it is the
+state the repository is in today at 1.3.0-on-master against 1.2.1-on-PyPI, and nothing
+currently notices it. A wizard that only ever starts from the beginning would walk past it.
+
+**The "has the PR been merged?" answer is not trusted.** Answering yes routes into the
+existing `publish` path, which re-reads the version, notes and consistency from
+`<remote>/master` and refuses if the bump is not actually there. So a wrong answer costs a
+refusal, not a tag on the wrong commit. This is deliberate: asking a human to confirm a
+git state and then acting on the answer is how the original failure worked.
+
+**`release` replaces `prepare` rather than joining it.** Two commands that both bump a
+version, one of which writes notes from scratch and one of which renames an accumulated
+section, is the situation that produces the wrong one being run. `prepare`'s guards — the
+canonical-remote resolution, the clean-tree check, `--no-commit --no-tag`, both suites and
+lint — carry over unchanged.
+
+**The branch is `v1.3.0-to-v1.3.1`; the commit subject is `v1.3.0 -> v1.3.1`.** The
+requested `->` cannot appear in a git ref, so the branch spells it out and the subject —
+which has no such restriction — uses the arrow. The subject is what shows up in
+`git log --oneline`, which is where it was wanted.
+
+**The PR is opened with `gh`, and its absence is a refusal, not a fallback.** Silently
+skipping the PR would leave a pushed branch that looks like a finished release. The script
+refuses and prints the exact `gh pr create` command to run by hand.
+
+**The Claude entry point is a skill, not a slash command or a prose section.** The
+request is "let's cut a new release" in ordinary conversation, which is what a skill's
+description matches on; a slash command only fires when someone types it. A skill file
+also gets both — skills are invocable by name, so `/cut-a-release` works from the same
+file. Prose in `AGENTS.md` was the third option and is the weakest: it is loaded as
+background, not as a procedure to follow, which is how an agent ends up reconstructing
+release steps from `git log`.
+
+**The skill drives the script; it does not restate it.** Any procedure written twice
+drifts, and the copy an agent reads would be the one nobody runs. The skill's job is
+judgement the script cannot make — reading the accumulated `Next Release` entries to
+propose `patch` vs `minor`, and surfacing the PR link — and then getting out of the way.
+Every gate stays in `release.sh`, where a session cannot argue with it: the script refuses,
+and the skill reports the refusal rather than working around it.
+
+**The release branch is pushed to the fork, not to the canonical remote.** `release.sh`
+already resolves the canonical remote by URL; the fork is then the sole remaining remote,
+and `--fork <remote>` disambiguates when there is more than one.
+
+## Risks / Trade-offs
+
+- **Two PRs both appending to `Next Release` conflict.** → Real and frequent, since every
+  PR touches the same few lines. Entries append at the end of the section, one line each,
+  so the conflict is textual and trivial; this is the cost of a single accumulating draft
+  and is cheaper than reconstructing the notes months later.
+- **Travis's shallow clone may not contain the base commit.** → The script fetches the
+  base before diffing and reports a clear error rather than passing vacuously. A gate that
+  silently passes when it cannot find the base is worse than no gate.
+- **The `No-release-note:` trailer can be used to route around the gate.** → Accepted. It
+  is recorded in the commit and visible in review, which makes it a decision someone made
+  rather than a step nobody took.
+- **A note written at PR time may not match what finally merges.** → Review already covers
+  the diff; the note is part of the diff.
+- **An agent could be asked to release something that should not ship.** → The skill adds
+  no authority. `release.sh` still refuses on an empty `Next Release`, a dirty tree, a
+  failing suite or a taken version, and the tag still requires a merged PR and a separate
+  `publish` run. The session can be wrong about *whether* to release; it cannot produce a
+  broken one.
+- **`gh` needs authentication in each maintainer's clone.** → One-time `gh auth login`,
+  and the refusal says so.
+
+## Migration Plan
+
+Ordering matters, because the outstanding 1.3.1 release already has its notes written by
+hand and carried in MQ-3307:
+
+1. Merge MQ-3307, which carries the script, the corrected docs and the 1.3.1 bump.
+2. Ship 1.3.1 with `release.sh publish`. This is the last release run the old way.
+3. Merge this change, adding an empty `Next Release` above the `Release: 1.3.1` entry and
+   turning the gate on. From here every PR carries its own note.
+4. The first `release.sh release <part>` run is whatever accumulates over the following
+   week or two.
+
+Rollback is dropping the `TOXENV=notes` matrix entry; nothing else in the release path
+depends on the gate.
+
+## Open Questions
+
+- Should `tools/` changes require a note? They can change how maintainers release without
+  changing what consumers see. Left exempt for now; revisit if it bites.
+- Is a scheduled nudge worth it — something that notices `Next Release` has been non-empty
+  for a fortnight? `status` already answers the question on demand, and a notification
+  nobody owns becomes noise. Deferred until the cadence has been tried by hand.

--- a/openspec/changes/enforce-release-notes-and-cadence/proposal.md
+++ b/openspec/changes/enforce-release-notes-and-cadence/proposal.md
@@ -1,0 +1,99 @@
+## Why
+
+Writing release notes is currently something a maintainer does from memory, months late,
+by reading `git log` — and it does not happen. Of the five PRs merged since 1.2.1
+(gh-#13 through gh-#17), **none** touched `docs/release_notes/index.rst`. The notes stopped
+at 1.0.0 while `setup.py` reached 1.3.0, and reconstructing the 1.3.0 entry afterwards
+required reading the diff of `0abb373` to discover that it had reverted most of 1.2.2.
+The person who knew what a change meant had moved on by the time anyone wrote it down.
+
+`harden-release-process` made the release mechanism safe: a tag can no longer land on an
+unmerged commit or reach a personal fork. It did not make releasing *routine*. It still
+begins with a maintainer deciding it is time, then authoring notes for eleven commits in
+one sitting, and there is nothing anywhere that tells a contributor a note is expected of
+them or a reader when the next release is due.
+
+## What Changes
+
+- **A persistent `Next Release` section** at the top of `docs/release_notes/index.rst`.
+  Contributors add their entry in the PR that makes the change, while they still know why
+  they made it. The section is the accumulating draft of the next release.
+- **A CI gate on that section.** A Travis `pull_request` build fails when the diff touches
+  `spektrum/` but adds no entry under `Next Release`. Docs-only, test-only and
+  tooling-only PRs are exempt. Travis already runs `pull_request` builds, so this needs a
+  `tox` environment, not new infrastructure.
+- **`tools/release.sh release <part>`,** a new subcommand between the existing `prepare`
+  and `publish`. It refuses when `Next Release` is empty, renames the section to
+  `Release: <version>`, opens a fresh empty `Next Release` above it, bumps the version,
+  runs both suites and lint, commits **one** commit on a branch named `v<old>-to-<new>`,
+  and opens the PR. `prepare` is replaced by it.
+- **`tools/release.sh` with no arguments is an interactive release.** It works out which
+  of five states the repository is in and does the next right thing: nothing merged, exit
+  saying so; changes waiting, show them and ask major/minor/patch; a release PR open, say
+  what to merge; **a release merged but never tagged, go straight to tagging** — the state
+  this repository has been in twice, and the one nothing currently detects. The
+  subcommands stay for scripting.
+- **A release-shaped commit subject.** The single commit and its PR are titled
+  `v1.3.0 -> v1.3.1`, so `git log --oneline` shows at a glance where each published
+  version begins and ends. Today a release is indistinguishable from any other merge.
+- **Tagging stays a separate step.** `release` prints the `publish` command and stops.
+  A tag can only ever be created on a commit that is already on `master` — the property
+  `harden-release-process` exists to protect, and the reason this is two commands rather
+  than one.
+- **A Claude entry point.** `.claude/skills/cut-a-release/SKILL.md`, so "let's cut a new
+  release" in a session does the right thing instead of the agent reconstructing the
+  procedure from `git log`. Skills are also invocable by name, so `/cut-a-release` works
+  for anyone who would rather type the command. The skill drives `tools/release.sh` — it
+  does not reimplement the steps, and it cannot talk its way past the script's refusals.
+- **A documented cadence.** Every one to two weeks *if* anything has merged, never on a
+  schedule for its own sake. `release.sh status` already answers "is there anything to
+  release"; the cadence gives it a reason to be run.
+- **Release information in `README.rst`.** Where published versions live, how to read the
+  notes, the cadence, and the one-line expectation for contributors: your PR carries its
+  own note. The README currently has an empty `Continuous Integration` heading and a
+  `Release Notes` section that is a single link.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — see below)_
+
+### Modified Capabilities
+
+_(none — see below)_
+
+This change sets `skip_specs: true`, consistent with `add-agent-docs`,
+`enforce-sdd-and-audit-docs` and `harden-release-process`. No file under `spektrum/` or
+`tests/` is touched; the library's public surface, CLI flags and reporters behave
+identically before and after. `openspec/specs/` is the baseline for *library* behaviour,
+and adding repository tooling to it would dilute exactly the baseline
+`enforce-sdd-and-audit-docs` exists to make trustworthy.
+
+## Impact
+
+- `tools/release.sh` — `release` added, `prepare` removed. Depends on MQ-3307, which
+  introduces the script; this change reshapes it rather than creating it.
+- `tools/check_release_notes.py` — new. The gate, written in Python so it is testable and
+  runnable locally rather than only inside CI.
+- `.travis.yml` — one `TOXENV=notes` matrix entry. The deploy block is untouched.
+- `tox.ini` — a `notes` environment so the gate runs identically locally and in CI.
+- `docs/release_notes/index.rst` — gains the `Next Release` section.
+- `docs/maintenance/index.rst` — `prepare` becomes `release`; the by-hand fallback and the
+  cadence follow it.
+- `README.rst`, `CONTRIBUTING.md`, `.github/pull_request_template.md` — the contributor
+  half of the rule, stated where a contributor is already looking.
+- `.claude/skills/cut-a-release/SKILL.md` — new. `.claude/` currently holds only
+  `conventions.md`; this is the first skill in the repo.
+- `AGENTS.md` — its release paragraph names `prepare`, and its file map lists `.claude/`.
+
+## Deferred
+
+- **Deriving the entry from the commit rather than asking for it.** Tempting, and wrong:
+  a commit subject says what was done, a release note says what a consumer will notice.
+  The MQ-3300 entry ("a completed run lost its entire report") is not recoverable from
+  "stop expect source lookup from crashing the reporter".
+- **The CI-side tag guard** already deferred by `harden-release-process`.
+- **Anything that requires a GitHub token in Travis.** Auto-tagging on merge was
+  considered and rejected: storing push credentials for the canonical repository in CI
+  widens what a compromised build can reach, for a step a maintainer runs in seconds.

--- a/openspec/changes/enforce-release-notes-and-cadence/tasks.md
+++ b/openspec/changes/enforce-release-notes-and-cadence/tasks.md
@@ -1,0 +1,144 @@
+> **Most of this landed in MQ-3307.** The `Next Release` section, `tools/release.sh`
+> (interactive mode, `release`, `publish`, `status`), the Claude skill and the
+> documentation shipped with the release-process commit, because the release could not be
+> run without them. What remains below is the **CI notes gate** (group 3) and the
+> contributor-facing wording that pairs with it, plus the hand-over steps.
+>
+> Until the gate exists, `Next Release` is enforced at release time only: `release.sh`
+> refuses when the section is empty. That catches the omission, but late — at the moment
+> nobody remembers what the change was for, which is the problem the gate exists to fix.
+
+## 1. Sequence the prerequisites
+
+- [x] 1.1 MQ-3307 carries the script, the docs and the 1.3.1 bump. Landed as one commit.
+- [ ] 1.2 Ship 1.3.1 with `./tools/release.sh publish` once MQ-3307 is on `master`, and
+      confirm it on PyPI. Its notes were written by hand; from 1.3.2 onward they come from
+      `Next Release`.
+- [ ] 1.3 Re-measure the claim in proposal.md — Why after a cycle with the gate off: of the
+      PRs merged, how many added a `Next Release` entry unprompted. It was 0 of 5 for
+      gh-#13 through gh-#17. That number is the argument for group 3.
+
+## 2. Add the Next Release section
+
+- [x] 2.1 Add a `Next Release` section at the top of `docs/release_notes/index.rst`, above
+      the newest `Release:` entry, using the same heading underline style.
+- [x] 2.2 Give it a `*Nothing yet.*` placeholder so Sphinx renders no bare heading and the
+      empty state is readable.
+- [x] 2.3 Confirm the file still renders through `docutils` with no warnings.
+
+## 3. Build the gate
+
+- [ ] 3.1 `tools/check_release_notes.py`: extract the `Next Release` body from a given
+      revision of the notes and count `#.` entries.
+- [ ] 3.2 Resolve the base revision — `TRAVIS_BRANCH` under Travis, otherwise the
+      merge-base with the canonical remote's `master`, resolved by URL as `release.sh`
+      does; `--base <ref>` overrides. Fetch the base first, because Travis clones shallow.
+- [ ] 3.3 Fail when the base-to-head diff touches `spektrum/` (excluding
+      `spektrum/vendor/`) and the head does not have strictly more entries than the base.
+      Exempt every other path.
+- [ ] 3.4 Honour a `No-release-note: <reason>` trailer in the head commit as an explicit,
+      reviewable exemption.
+- [ ] 3.5 Report a failure that names the file, the missing entry and the format to add —
+      not just that a check failed.
+- [ ] 3.6 Error, rather than pass, when the base commit cannot be resolved. A gate that
+      passes vacuously is worse than no gate.
+- [ ] 3.7 Unit tests under `tests/` covering: `spektrum/` touched with no new entry
+      (fails); with a new entry (passes); docs-only diff (exempt); `spektrum/vendor/` only
+      (exempt); `No-release-note:` trailer present (passes); base unresolvable (errors).
+- [ ] 3.8 Add a `notes` environment to `tox.ini` running the script, so the local command
+      and the CI command are the same one.
+- [ ] 3.9 Add `TOXENV=notes` to the `.travis.yml` matrix. Do not touch the deploy block.
+
+## 4. Replace `prepare` with `release`
+
+- [x] 4.1 Add `release <major|minor|patch>` to `tools/release.sh`, carrying over every
+      guard from `prepare`: canonical remote resolved by URL, clean tree, tag and PyPI
+      collision checks, `bumpversion --allow-dirty --no-commit --no-tag`, both suites and
+      flake8.
+- [x] 4.2 Refuse when `Next Release` holds no entries — that is the signal there is
+      nothing to release, and it should read as such rather than as an error.
+- [x] 4.3 Rename `Next Release` to `Release: <new version>`, dropping the placeholder, and
+      open a fresh empty `Next Release` above it.
+- [x] 4.4 Commit one commit on a branch named `v<old>-to-v<new>`, subject `v<old> -> v<new>`.
+- [x] 4.5 Push to the fork — the remaining remote once the canonical one is identified —
+      with `--fork <remote>` to disambiguate.
+- [x] 4.6 Open the PR with `gh pr create` against the canonical repository, base `master`.
+      Refuse and print the exact command if `gh` is missing or unauthenticated; never
+      leave a pushed branch that looks like a finished release.
+- [x] 4.7 Print the `publish` command and stop. Do not tag: the commit to tag does not
+      exist until the PR merges.
+- [x] 4.8 Remove `prepare`, and make the removed name print a pointer to `release` rather
+      than an unknown-command error.
+- [x] 4.9 Extend `status` to report how many entries are sitting under `Next Release`, so
+      it answers whether a release is due.
+
+- [x] 4.10 Bare `tools/release.sh`, no arguments: detect which of the five states in
+      design.md the repository is in and dispatch. The subcommands stay for scripting.
+- [x] 4.11 Nothing merged since the released tag: print the current version and exit 0
+      saying there is nothing to release. Not an error.
+- [x] 4.12 Changes waiting: list them, show `<current> -> <each candidate>` and prompt for
+      major, minor or patch, then run the `release` path.
+- [x] 4.13 After the PR is opened, prompt whether it has merged. Yes routes into `publish`,
+      whose own checks re-read `<remote>/master` — a wrong answer must cost a refusal, not
+      a bad tag. No prints the `./tools/release.sh publish` command and exits 0.
+- [x] 4.14 Merged-but-never-tagged: detect it on entry and go straight to the tag step.
+      Verify against the current tree, which is in exactly this state — 1.3.0 on master,
+      1.2.1 on PyPI.
+- [x] 4.15 Notes-missing: refuse and name the merged PRs that added no entry, rather than
+      offering a release with nothing to say about it.
+- [x] 4.16 Non-interactive safety: with no tty, refuse rather than assuming a default.
+
+## 5. Write it down where people look
+
+- [x] 5.1 `README.rst`: a Releases section — where published versions live, the one-to-two
+      week cadence, that a release happens only if something merged, and the one-line
+      contributor expectation. Fill the empty `Continuous Integration` heading while there.
+- [x] 5.2 `docs/maintenance/index.rst`: `prepare` becomes `release`; document the cadence
+      and update the by-hand fallback to include the section rename.
+- [ ] 5.3 `CONTRIBUTING.md` and `.github/pull_request_template.md`: add the note
+      requirement to the pre-PR checklist and the template, including the
+      `No-release-note:` trailer.
+- [x] 5.4 `AGENTS.md`: its release paragraph names `prepare`.
+
+## 6. Make it reachable from a Claude session
+
+- [x] 6.1 `.claude/skills/cut-a-release/SKILL.md`, with a description that matches
+      "cut a release", "ship a version", "is there anything to release" and the like, so
+      it fires from ordinary conversation as well as from `/cut-a-release`.
+- [x] 6.2 The skill runs `./tools/release.sh status` first and reports what is waiting —
+      including the case where `Next Release` is empty and the answer is "nothing to
+      release today".
+- [x] 6.3 It reads the accumulated `Next Release` entries and proposes `patch`, `minor` or
+      `major` with its reasoning, then asks before running. This is the judgement the
+      script deliberately does not make.
+- [x] 6.4 It runs `./tools/release.sh release <part>` and surfaces the PR link. It must
+      not reimplement any step, and must not work around a refusal — a refusal is reported
+      to the user as-is.
+- [x] 6.5 It knows the second half: after the PR merges, `./tools/release.sh publish`, and
+      that a tag on an unmerged commit is the failure the whole process exists to prevent.
+- [x] 6.6 `AGENTS.md`: point at the skill from the release section, and add
+      `.claude/skills/` to the file map.
+- [ ] 6.7 Verify in a real session that "let's cut a new release" reaches the skill, and
+      that a refusal from the script is reported rather than routed around.
+
+## 7. Verify
+
+- [x] 7.1 `python -m pytest tests -q` and `python -m spektrum -s tests/live/` both pass;
+      record counts. Red-then-green for the gate's own tests.
+- [ ] 7.2 `tox -e flake8` clean; `tox -e notes` runs locally and reaches the same verdict
+      as CI on the same diff.
+- [ ] 7.3 Exercise the gate on real PRs from this repository's history: gh-#15 (touches
+      `spektrum/`, no note — must fail) and gh-#16 (docs only — must pass).
+- [x] 7.4 Exercise `release` end to end against a bare repository named to match the
+      canonical slug, as `harden-release-process` did: section renamed, one commit, branch
+      and subject correct, no tag created.
+- [x] 7.5 Confirm `docutils` renders both changed `.rst` files with no warnings, and
+      `openspec validate --all` passes.
+
+## 8. Hand over
+
+- [ ] 8.1 Both maintainers run `gh auth login` once so `release` can open the PR.
+- [ ] 8.2 Run the first real `release` at the end of the first one-to-two week window.
+- [ ] 8.3 Revisit the two open questions in design.md once the cadence has been tried:
+      whether `tools/` changes should require a note, and whether a scheduled nudge earns
+      its noise.

--- a/openspec/changes/harden-release-process/.openspec.yaml
+++ b/openspec/changes/harden-release-process/.openspec.yaml
@@ -1,0 +1,3 @@
+schema: spec-driven
+created: 2026-08-28
+skip_specs: true

--- a/openspec/changes/harden-release-process/design.md
+++ b/openspec/changes/harden-release-process/design.md
@@ -1,0 +1,116 @@
+## Context
+
+Releasing Spektrum is one mechanical act with a long gap in the middle. The version bump
+and the release notes go through code review; the tag that actually publishes can only be
+created after that review merges. Every failure this change addresses lives in that gap.
+
+`bumpversion` is configured `commit = True, tag = True`, so it produces both in one step,
+on whatever commit it is run on. Run on a branch — which is the only place it can be run,
+since the bump needs review — it tags a commit that the merge will rewrite. The tag is
+then correct about nothing: not the version's content, not its history, not its
+reachability. `git log` shows the bump landing on `master` under a new SHA while the tag
+stays behind on the old one, which is why this reads as working until someone checks PyPI
+months later.
+
+The current state, measured:
+
+| | |
+|---|---|
+| PyPI latest | 1.2.1, 2025-06-11, Travis build #68 |
+| `master` | 1.3.0 + 3 merged PRs, `b7c2850` |
+| Tags never pushed anywhere | `v1.2.2` → `87916dc`, `v1.3.0` → `3bb7e89` |
+| Local tags disagreeing with the canonical repo | `v1.2.0`, `v1.2.1` |
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A maintainer who knows nothing about the history can release correctly by running two
+  commands, and cannot produce a dangling tag by following them.
+- Every refusal names the fix. A check that prints only "failed" returns the reader to the
+  process that just misled them.
+- The drift that hid two lost releases is visible on demand, before the next release
+  rather than after it.
+
+**Non-Goals**
+
+- Migrating CI. Travis works — #68 published 1.2.1, and #81–83 are green on `master`.
+  Replacing it is a larger change with its own risk, and it is not what broke.
+- Enforcement inside CI. Worth doing, deferred deliberately; see proposal.md.
+- Retroactively publishing 1.2.2 or 1.3.0. PyPI goes 1.2.1 → 1.3.1 and the notes carry
+  the 1.3.0 entry so nothing is undocumented.
+- Fixing `tools/run_tests.sh`, which calls `nosetests`. Pre-existing, unrelated.
+
+## Decisions
+
+**Two subcommands, not one.** A release is two events separated by a review, and a single
+command would have to guess which side of the merge it is on. `prepare` and `publish` name
+the phase, and each states what the other does next.
+
+**Resolve the remote by URL, never by name.** `origin` is a personal fork for both
+maintainers, and pushing the tag to the fork is half of what lost both releases. The script
+scans `git remote -v` for the canonical slug and refuses when zero or more than one remote
+matches, rather than defaulting to `upstream` — a name that is a local convention, not a
+guarantee.
+
+**`--allow-dirty --no-commit --no-tag`, always.** `bumpversion` still writes the three
+version files, so the tool stays authoritative for the bump, but it never creates the
+artefact it gets wrong. `--allow-dirty` is required because the release notes are edited
+before the bump, by design: a version with no notes is not releasable.
+
+**`publish` reads the canonical `master`, not the working tree.** Version, notes and
+consistency are all read through `git show <remote>/master:<path>`. What gets tagged is
+what is on the canonical master, whatever state the local clone is in.
+
+**Notes before version.** `prepare` refuses until `docs/release_notes/index.rst` has a
+section for the new version, and prints the heading to paste plus the commits merged since
+the last release. This inverts the old order, in which the notes were a step someone could
+skip and nothing noticed — the release notes stopped at 1.0.0 while `setup.py` said 1.3.0.
+
+**Type the version to confirm.** A y/n prompt is answered reflexively. PyPI versions cannot
+be reused, replaced or deleted-and-reuploaded, so the last gate before an irreversible
+action asks for something that cannot be typed by accident.
+
+**Wait for PyPI rather than trusting the push.** A pushed tag is not a release; it is a
+request for one. The script polls for the version and, on timeout, points at the build —
+which is where a revoked `PYPI_TOKEN` would show up.
+
+**Fetch the branch, not `--tags`.** `git fetch --tags` exits non-zero on "would clobber
+existing tag", which is precisely the state a clone is left in by a failed release. Under
+`set -e` that killed the script on its first command, for a condition `status` exists to
+report. Found by running `status` against this repository, where local `v1.2.1` disagrees
+with the canonical one.
+
+## Risks / Trade-offs
+
+- **A tag pushed by hand still bypasses everything.** The script cannot prevent
+  `git push upstream v9.9.9`. Only a CI-side guard closes this, and that is deferred. The
+  mitigation meanwhile is that `status` reports the damage.
+- **`bash` and `awk` dependency.** Avoided `declare -A` so the script runs on bash 3.2
+  (macOS) as well as 4+. Not tested on macOS; both maintainers are on Linux.
+- **The 15-minute PyPI poll can outlive a slow build.** Timing out is not a failure — the
+  tag is pushed and the release is in flight. The message says so, rather than implying
+  the release was lost.
+- **`status` costs two network calls** (PyPI, `git ls-remote`). It is read-only and cheap
+  enough to run habitually, which is the point.
+
+## Migration Plan
+
+No migration. The script is additive and the documents it corrects have no consumers other
+than maintainers. The stale local tags (`v1.2.2`, `v1.3.0`, and the divergent `v1.2.0` /
+`v1.2.1`) are each maintainer's own clone to clean up; `status` names them and
+`git tag -d` removes them. Nothing on the canonical repository changes.
+
+The first real exercise is the outstanding 1.3.1 release, which reaches `publish` with the
+prepare PR already written by hand.
+
+## Open Questions
+
+- Is `PYPI_TOKEN` still valid? Unused since 2025-06-11. A repo admin can read and rotate
+  it in Travis repository settings, so this is a check to run rather than access to
+  obtain — but it stays unverified until a tag build actually deploys.
+- Who holds maintainer rights on the Spektrum project on PyPI? Minting a replacement token
+  requires it, and nothing in the repository records it.
+- Should `v1.2.2` and `v1.3.0` be published retroactively from their dangling commits
+  rather than skipped? Assumed no — the content is already in `master` and reaches users
+  in 1.3.1 — but it is the maintainer's call, not the script's.

--- a/openspec/changes/harden-release-process/proposal.md
+++ b/openspec/changes/harden-release-process/proposal.md
@@ -1,0 +1,87 @@
+## Why
+
+Publishing Spektrum is a single mechanical act — push a tag to
+`liquidweb/Spektrum` and Travis uploads to PyPI — and the repository documents it
+wrongly. `docs/maintenance/index.rst` is the only release document, and following it
+exactly produces a release that never happens:
+
+```
+#. Push up branch and tag
+     git push origin prep_for_release --tags
+```
+
+Two defects in three lines. The tag is created by `bumpversion` on the branch, so it
+points at the pre-merge commit that the merge then rewrites; and it is pushed to
+`origin`, which is a personal fork for both maintainers, while Travis watches
+`liquidweb/Spektrum`. The document then closes with a manual `twine upload dist/*`,
+which duplicates the CI deploy and requires PyPI credentials neither maintainer holds.
+
+This is not hypothetical. Two versions have been lost to exactly this:
+
+| Version | On PyPI | Tag                  | Reachable from `master` |
+|---------|---------|----------------------|-------------------------|
+| 1.2.2   | no      | local only, `87916dc` | no                     |
+| 1.3.0   | no      | local only, `3bb7e89` | no                     |
+
+PyPI's latest is 1.2.1, published 2025-06-11 by Travis build #68 — the last tag build
+this repository has had. `master` has since reached 1.3.0 plus three more merged PRs.
+Neither maintainer could state the release procedure from memory, which is the expected
+outcome when the written procedure is wrong: there is nothing correct to remember.
+
+## What Changes
+
+- **Add `tools/release.sh`,** a two-phase driver that refuses rather than warns. It
+  resolves the canonical remote by URL instead of trusting a remote name, insists the
+  release notes exist before it will bump a version, bumps with `--no-commit --no-tag`
+  so no tag can land on a pre-merge commit, and tags the canonical `master` directly in
+  a separate phase run after the PR merges.
+- **Add a `status` subcommand.** Read-only drift report: what PyPI has, what `master`
+  claims, whether the notes are written, and every local tag that disagrees with the
+  canonical repository. Run against the current tree it names all four bad tags. Had it
+  existed, 1.2.2 would have been caught before 1.3.0 repeated it.
+- **Rewrite `docs/maintenance/index.rst`** to the process that actually publishes,
+  leading with the one fact that matters — pushing a tag to the canonical repository is
+  the release — and keeping a by-hand fallback for when the script cannot run.
+- **Correct `AGENTS.md`.** Its release paragraph inverts the risk, warning that "a
+  version bump in an ordinary PR ships a release by accident". A bump in a PR ships
+  nothing; only a pushed tag does. The stated danger is the opposite of the real one.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — see below)_
+
+### Modified Capabilities
+
+_(none — see below)_
+
+This change sets `skip_specs: true`. It alters no Spektrum behaviour: every deliverable
+is repository tooling or documentation. No file under `spektrum/` or `tests/` is touched,
+and the library's public surface, CLI flags and reporters are identical before and after.
+Specs describe behaviour, so inventing a requirement here would put a false entry in the
+baseline.
+
+## Impact
+
+- `tools/release.sh` — new. `tools/` currently holds only `run_tests.sh`, which invokes
+  `nosetests` and has not worked since before the pytest migration; out of scope here.
+- `docs/maintenance/index.rst` — rewritten. Also fixes a short title underline that
+  `docutils` warns on today.
+- `AGENTS.md` — the "Versions and releasing" section. `CLAUDE.md` is a symlink to it and
+  needs no separate edit.
+- `.travis.yml` — unchanged. Travis is active and green (builds #81–83 on `master`), and
+  build #68 proves the tag-triggered deploy works. The publish step stays where it is.
+
+## Deferred
+
+- **CI-side enforcement.** A guard rejecting a tag build whose commit is not an ancestor
+  of `master`, or whose tag disagrees with `setup.py`, would close the hole for a tag
+  pushed by hand rather than through the script. It belongs in `.travis.yml` and is its
+  own change.
+- **Confirming `PYPI_TOKEN` still works.** It has not been exercised since 2025-06-11.
+  It is a Travis *repository*-level secret and Travis mirrors GitHub repository
+  permissions, so a repo admin can read and rotate it — a check to perform, not an access
+  problem to escalate. What is genuinely unrecorded is who holds maintainer rights on the
+  Spektrum project on PyPI, which is what minting a replacement token requires. The
+  script surfaces the symptom by reporting the build URL when PyPI does not update.

--- a/openspec/changes/harden-release-process/tasks.md
+++ b/openspec/changes/harden-release-process/tasks.md
@@ -1,0 +1,74 @@
+## 1. Establish what is actually broken
+
+- [x] 1.1 Confirm the publish trigger. `.travis.yml` has `deploy.on.tags: true` with
+      `provider: pypi`, `username: __token__`, `password: $PYPI_TOKEN`,
+      `skip_existing: true`. **A pushed tag is the only thing that publishes.**
+- [x] 1.2 Confirm Travis is still active. Repository is `active: true`; builds #81–83 on
+      `master` passed on 2026-08-28. Build #68 is the last tag build, `v1.2.1`,
+      2025-06-11, which matches PyPI's upload timestamp for 1.2.1.
+- [x] 1.3 Confirm the lost releases. `v1.2.2` → `87916dc` and `v1.3.0` → `3bb7e89`; neither
+      is an ancestor of `upstream/master`, and neither exists on `liquidweb/Spektrum` or on
+      the fork. PyPI's latest is 1.2.1.
+- [x] 1.4 Confirm the documented process reproduces the failure.
+      `docs/maintenance/index.rst` says `git push origin prep_for_release --tags`, with the
+      tag created by `bumpversion` on the branch. Both defects, in one step.
+
+## 2. Build the driver
+
+- [x] 2.1 `tools/release.sh` with `status`, `prepare <part>` and `publish`.
+- [x] 2.2 Resolve the canonical remote by URL; refuse on zero or multiple matches.
+- [x] 2.3 `prepare`: refuse until the notes for the new version exist, printing the
+      heading to paste and the commits merged since the last release.
+- [x] 2.4 `prepare`: bump via `bumpversion --allow-dirty --no-commit --no-tag`, then run
+      both suites and flake8. Do not commit.
+- [x] 2.5 `prepare`: re-runnable. The first run stops at the notes check, and the second
+      must not discard the notes just written.
+- [x] 2.6 `publish`: read version, notes and consistency from `<remote>/master`, not the
+      working tree.
+- [x] 2.7 `publish`: refuse on an existing tag (local-but-different, or on the remote), on
+      a version already on PyPI, and on version files that disagree.
+- [x] 2.8 `publish`: require the version typed to confirm; refuse in a non-tty without
+      `--yes`.
+- [x] 2.9 `publish`: tag the canonical `master` commit, push the tag to the canonical
+      remote, then poll PyPI and report the build URL on timeout.
+- [x] 2.10 `status`: classify every local tag against the canonical repository —
+      never pushed, or disagreeing — and resolve the "merged since" range from the
+      remote's tag rather than the local one.
+
+## 3. Verify the driver against reality
+
+- [x] 3.1 `status` against this repository. Names `v1.2.2`, `v1.3.0` and `v1.2.0` as never
+      pushed and `v1.2.1` as disagreeing; reports 1.3.0 on master against 1.2.1 on PyPI.
+- [x] 3.2 Refusals, each observed: bad `<part>`; `prep_for_release` existing but not
+      checked out; dirty tree at branch creation; missing notes; notes missing on
+      `<remote>/master` at publish time; non-tty confirmation.
+- [x] 3.3 Full `prepare` path in a scratch clone: branch cut, notes refusal, notes written,
+      re-run bumps all three files to 1.3.1, 175 pytest + 22 spec cases + flake8 clean.
+- [x] 3.4 Full `publish` path against a bare repository named to match the canonical slug.
+      Annotated `v1.3.1` created on the canonical master's exact SHA and pushed; re-running
+      refuses because the remote now has the tag.
+- [x] 3.5 Regression found by 3.1 and fixed: `git fetch --tags` aborts the script on
+      "would clobber existing tag". Fetch the branch only.
+- [x] 3.6 Regression found by 3.1 and fixed: local branches named `v1.2.0` / `v1.2.1`
+      shadow the tags of the same name. Use `refs/tags/` everywhere.
+
+## 4. Correct the documents
+
+- [x] 4.1 Rewrite `docs/maintenance/index.rst`: lead with the publish trigger, both
+      phases, what each check refuses, and a by-hand fallback. Fix the short title
+      underline that `docutils` warns on.
+- [x] 4.2 Correct `AGENTS.md`'s "Versions and releasing". It currently warns that a bump
+      in an ordinary PR "ships a release by accident" — the opposite of the truth.
+- [x] 4.3 Confirm `docs/maintenance/index.rst` renders through `docutils` with no
+      warnings.
+
+## 5. Hand over
+
+- [ ] 5.1 Both maintainers run `./tools/release.sh status` on their own clone and clear
+      the stale tags it names.
+- [ ] 5.2 Use `publish` for the outstanding 1.3.1 release — the first real exercise.
+- [ ] 5.3 Confirm `PYPI_TOKEN` is still valid before a release depends on it — unused
+      since 2025-06-11. Travis repository settings, reachable by anyone with admin on
+      `liquidweb/Spektrum`. Separately, record who holds maintainer rights on the Spektrum
+      project on PyPI, since that is what minting a replacement requires.
+- [ ] 5.4 Open the deferred change for a CI-side tag guard.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_desc = None
 if os.path.exists('README.rst'):
     long_desc = open('README.rst').read()
 
-version = '1.3.0'
+version = '1.3.1'
 
 setup(
     name='Spektrum',

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,758 @@
+#!/usr/bin/env bash
+#
+# Release driver for Spektrum.  Prose version: docs/maintenance/index.rst
+#
+# A release is two events separated by a code review, so this is two commands:
+#
+#   ./tools/release.sh prepare <major|minor|patch>
+#       Cuts prep_for_release from the canonical master, refuses until the
+#       release notes for the new version exist, bumps the version, and runs
+#       both suites and lint.  Leaves the commit to you.
+#
+#   ./tools/release.sh publish
+#       Run once that PR has merged.  Tags the merge commit on the canonical
+#       master and pushes the tag there.  Pushing that tag is the only thing
+#       that publishes to PyPI.
+#
+#   ./tools/release.sh status
+#       What is released, what is tagged, and what has drifted.  Read-only.
+#
+# Every check below refuses rather than warns.  The two releases this script
+# exists to prevent -- v1.2.2 and v1.3.0, neither of which reached PyPI -- were
+# both produced by following the old documented process correctly.
+
+set -euo pipefail
+
+PACKAGE='Spektrum'
+CANONICAL_SLUG='liquidweb/Spektrum'
+NEXT_HEADING='Next Release'
+NOTES='docs/release_notes/index.rst'
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------- output ----
+
+if [ -t 1 ]; then
+    C_RED=$'\033[31m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'
+    C_BOLD=$'\033[1m'; C_OFF=$'\033[0m'
+else
+    C_RED=''; C_GREEN=''; C_YELLOW=''; C_BOLD=''; C_OFF=''
+fi
+
+ok()   { printf '  %s✓%s %s\n' "$C_GREEN" "$C_OFF" "$1"; }
+info() { printf '  %s·%s %s\n' "$C_YELLOW" "$C_OFF" "$1"; }
+head_() { printf '\n%s%s%s\n' "$C_BOLD" "$1" "$C_OFF"; }
+
+# Refuse loudly, and always say what to do instead.  A check that only prints
+# "failed" sends the reader back to the process they already got wrong.
+# stderr, not stdout.  `canonical_remote` is called as `$(canonical_remote)`, and a
+# refusal printed to stdout there is captured by the command substitution and never
+# reaches the reader -- the script exits 1 in silence, which is the one thing every
+# message here exists to avoid.
+refuse() {
+    printf '\n  %s✗ %s%s\n' "$C_RED" "$1" "$C_OFF" >&2
+    shift
+    local arg line
+    for arg in "$@"; do
+        while IFS= read -r line; do
+            printf '    %s\n' "$line" >&2
+        done <<<"$arg"
+    done
+    printf '\n' >&2
+    exit 1
+}
+
+# ----------------------------------------------------------------- remote ----
+
+# `origin` is a personal fork for both maintainers, and the fork is where the
+# lost tags went.  Never assume a remote name -- find the one that actually
+# points at the canonical repository, and refuse if it is ambiguous.
+canonical_remote() {
+    local found=()
+    local remote url
+    while read -r remote url _; do
+        case "$url" in
+            *"$CANONICAL_SLUG"*|*"${CANONICAL_SLUG%.git}.git"*) found+=("$remote") ;;
+        esac
+    done < <(git remote -v | awk '$3 == "(fetch)"')
+
+    # De-duplicate, in case one remote is listed more than once.
+    local uniq
+    uniq="$(printf '%s\n' "${found[@]:-}" | sort -u | grep -v '^$' || true)"
+    local count
+    count="$(printf '%s' "$uniq" | grep -c . || true)"
+
+    if [ "$count" -eq 0 ]; then
+        refuse "No remote points at $CANONICAL_SLUG." \
+               "This clone can only see forks, and a tag pushed to a fork never" \
+               "reaches CI -- that is how v1.2.2 and v1.3.0 were lost.  Add it:" \
+               "" \
+               "  git remote add upstream git@github.com:$CANONICAL_SLUG.git"
+    fi
+    if [ "$count" -gt 1 ]; then
+        refuse "More than one remote points at $CANONICAL_SLUG:" "$uniq" \
+               "" "Remove the duplicate so there is no doubt where the tag goes."
+    fi
+    printf '%s' "$uniq"
+}
+
+# ---------------------------------------------------------------- helpers ----
+
+# Deliberately not --tags.  A clone that has been through a failed release
+# holds tags that disagree with the canonical repo's, and `git fetch --tags`
+# exits non-zero on "would clobber existing tag" -- which under `set -e` kills
+# the script at the first command, for a condition `status` is meant to report.
+fetch_master() {  # fetch_master <remote>
+    git fetch --quiet "$1" master || refuse \
+        "Could not fetch master from $1." \
+        "Check network access and that you can read $CANONICAL_SLUG."
+}
+
+remote_tag_sha() {  # remote_tag_sha <remote> <tag>
+    git ls-remote --tags "$1" "refs/tags/$2" 2>/dev/null | awk '
+        {
+            name = $2
+            if (sub(/\^\{\}$/, "", name)) { peeled = $1 }
+            else { plain = $1 }
+        }
+        END { print (peeled != "" ? peeled : plain) }
+    '
+}
+
+version_from() {  # version_from <git-ref>
+    git show "$1:setup.py" | sed -n "s/^version = '\(.*\)'$/\1/p"
+}
+
+bumpversion_current_from() {  # bumpversion_current_from <git-ref>
+    git show "$1:.bumpversion.cfg" | sed -n 's/^current_version = \(.*\)$/\1/p'
+}
+
+conf_version_from() {  # conf_version_from <git-ref>
+    git show "$1:docs/conf.py" | sed -n "s/^version = '\(.*\)'$/\1/p"
+}
+
+notes_has_version() {  # notes_has_version <git-ref-or-WORKTREE> <version>
+    if [ "$1" = 'WORKTREE' ]; then
+        grep -qx "Release: $2" "$NOTES"
+    else
+        git show "$1:$NOTES" | grep -qx "Release: $2"
+    fi
+}
+
+# Three answers, not two.  Treating an unreachable PyPI as "the version is free" would
+# let `publish` tag and push having verified nothing -- a check that passes when it
+# cannot run is worse than no check.
+pypi_state() {  # pypi_state <version> -> published | absent | unknown
+    local code
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+        "https://pypi.org/pypi/$PACKAGE/$1/json" 2>/dev/null || printf '000')"
+    case "$code" in
+        200) printf 'published' ;;
+        404) printf 'absent' ;;
+        *)   printf 'unknown' ;;
+    esac
+}
+
+# Refuse on `unknown`; callers that legitimately tolerate it call pypi_state directly.
+require_absent_from_pypi() {  # require_absent_from_pypi <version>
+    case "$(pypi_state "$1")" in
+        published)
+            refuse "$PACKAGE $1 is already on PyPI." \
+                   "PyPI never lets a version be reused, replaced or re-uploaded." ;;
+        unknown)
+            refuse "Could not reach PyPI to check whether $1 is already published." \
+                   "Refusing rather than guessing -- publishing over an existing" \
+                   "version is not recoverable.  Check the network and re-run." ;;
+    esac
+}
+
+pypi_latest() {
+    curl -sS --max-time 20 "https://pypi.org/pypi/$PACKAGE/json" 2>/dev/null \
+        | python3 -c 'import json,sys
+try:
+    sys.stdout.write(json.load(sys.stdin)["info"]["version"])
+except Exception:
+    pass' 2>/dev/null
+}
+
+next_version() {  # next_version <current> <part>
+    local cur="$1" part="$2"
+    local major minor patch
+    IFS=. read -r major minor patch <<<"$cur"
+    case "$part" in
+        major) printf '%s.0.0' "$((major + 1))" ;;
+        minor) printf '%s.%s.0' "$major" "$((minor + 1))" ;;
+        patch) printf '%s.%s.%s' "$major" "$minor" "$((patch + 1))" ;;
+    esac
+}
+
+# The fork is whatever remote is not the canonical one.  A release branch is pushed
+# there, never to the canonical repository -- the PR comes from a fork like every other.
+fork_remote() {
+    local canonical="$1" found=() r
+    for r in $(git remote); do
+        [ "$r" = "$canonical" ] || found+=("$r")
+    done
+    if [ "${#found[@]}" -eq 0 ]; then
+        refuse "No remote to push a release branch to." \
+               "Only $canonical is configured, and that is the canonical repository." \
+               "Add your fork:" "" "  git remote add origin git@github.com:<you>/Spektrum.git"
+    fi
+    if [ "${#found[@]}" -gt 1 ]; then
+        refuse "More than one remote could be your fork: ${found[*]}" \
+               "Name it explicitly:  --fork <remote>"
+    fi
+    printf '%s' "${found[0]}"
+}
+
+remote_owner() {  # remote_owner <remote> -> github owner
+    git remote get-url "$1" \
+        | sed -E 's#^git@[^:]+:##; s#^https?://[^/]+/##; s#\.git$##' \
+        | cut -d/ -f1
+}
+
+# --- release notes -----------------------------------------------------------
+# The notes are RST with a fixed shape, so they are edited with python rather than
+# sed: getting a heading underline wrong silently breaks the published docs.
+
+notes_next_count() {  # notes_next_count <file> -> number of entries under Next Release
+    python3 - "$1" "$NEXT_HEADING" <<'PY'
+import re, sys
+text = open(sys.argv[1]).read()
+head = sys.argv[2]
+m = re.search(r'^%s\n-+\n(.*?)(?=^Release: |\Z)' % re.escape(head), text, re.M | re.S)
+print(len(re.findall(r'^ #\. ', m.group(1), re.M)) if m else -1)
+PY
+}
+
+notes_rename_next() {  # notes_rename_next <file> <version>
+    python3 - "$1" "$2" "$NEXT_HEADING" <<'PY'
+import re, sys
+path, version, head = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(path).read()
+
+m = re.search(r'^(%s)\n(-+)\n' % re.escape(head), text, re.M)
+if not m:
+    sys.exit('no "%s" section in %s' % (head, path))
+
+rule = m.group(2)
+# Rename this section to the version, then open a fresh empty one above it.
+text = text[:m.start()] + 'Release: %s\n%s\n' % (version, rule) + text[m.end():]
+
+fresh = '%s\n%s\n\n*Nothing yet.*\n\n' % (head, rule)
+insert = text.index('Release: %s\n' % version)
+text = text[:insert] + fresh + text[insert:]
+
+# The placeholder is a property of an empty section only.
+text = re.sub(r'(^Release: %s\n-+\n\n)\*Nothing yet\.\*\n\n' % re.escape(version),
+              r'\1', text, flags=re.M)
+open(path, 'w').write(text)
+PY
+}
+
+# setup.py, docs/conf.py and .bumpversion.cfg must agree before anything is bumped or
+# tagged.  bumpversion aborts with a Python traceback when they do not -- and in `release`
+# it would do so after the notes had already been rewritten, leaving a half-made release.
+require_consistent_versions() {  # require_consistent_versions <git-ref> -> version
+    local ref="$1" version cfg conf
+    version="$(version_from "$ref")"
+    cfg="$(bumpversion_current_from "$ref")"
+    conf="$(conf_version_from "$ref")"
+
+    [ -n "$version" ] || refuse "Could not read a version from $ref:setup.py."
+
+    if [ "$version" != "$cfg" ] || [ "$version" != "$conf" ]; then
+        refuse "Version files on $ref disagree." \
+               "  setup.py         $version" \
+               "  .bumpversion.cfg $cfg" \
+               "  docs/conf.py     $conf" \
+               "" "bumpversion cannot run against these.  Fix them in their own PR."
+    fi
+    printf '%s' "$version"
+}
+
+require_clean_tree() {
+    if [ -n "$(git status --porcelain)" ]; then
+        refuse "Working tree is not clean." \
+               "Commit or stash first -- a release must be cut from a known tree." \
+               "" "$(git status --short)"
+    fi
+}
+
+# ---------------------------------------------------------------- release ----
+
+cmd_release() {
+    local part='' fork=''
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            major|minor|patch) part="$1"; shift ;;
+            --fork) fork="${2:-}"; shift 2 ;;
+            *) refuse "Unknown argument: $1" "Usage: tools/release.sh release <major|minor|patch> [--fork <remote>]" ;;
+        esac
+    done
+    [ -n "$part" ] || refuse "Usage: tools/release.sh release <major|minor|patch>"
+
+    local remote; remote="$(canonical_remote)"
+    [ -n "$fork" ] || fork="$(fork_remote "$remote")"
+
+    head_ "Releasing a $part version"
+    info "canonical: $remote ($CANONICAL_SLUG)   fork: $fork"
+
+    fetch_master "$remote"
+    require_clean_tree
+
+    local base_version new_version
+    base_version="$(require_consistent_versions "$remote/master")"
+    new_version="$(next_version "$base_version" "$part")"
+    ok "$base_version -> $new_version"
+
+    git rev-parse -q --verify "refs/tags/v$new_version" >/dev/null && refuse \
+        "Tag v$new_version already exists locally." "" "  git tag -d v$new_version"
+    require_absent_from_pypi "$new_version"
+    ok "v$new_version is free, locally and on PyPI"
+
+    local branch="v$base_version-to-v$new_version"
+    if git rev-parse -q --verify "refs/heads/$branch" >/dev/null; then
+        if [ -z "$(git log --oneline "$remote/master..$branch" 2>/dev/null)" ]; then
+            # No commit on it: a previous attempt stopped before committing, most
+            # likely on a failing suite.  Nothing is lost by starting over.
+            refuse "Branch $branch exists but carries no commit." \
+                   "A previous attempt stopped before committing.  Delete it and" \
+                   "re-run:" "" "  git branch -D $branch"
+        fi
+        refuse "Branch $branch already has a release commit on it." \
+               "That release is in progress.  Merge its PR, then:" \
+               "" "  ./tools/release.sh publish"
+    fi
+    git checkout --quiet -b "$branch" "$remote/master"
+    ok "cut $branch from $remote/master ($(git rev-parse --short HEAD))"
+
+    head_ 'Verifying'
+    local py="${PYTHON:-python}"
+    command -v "$py" >/dev/null 2>&1 || refuse \
+        "\`$py\` is not on PATH." "Activate the virtualenv, or set PYTHON=python3."
+    "$py" -m pytest tests -q
+    "$py" -m spektrum -s tests/live/
+    "$py" -m flake8 spektrum tests && ok 'flake8 clean'
+
+    local entries; entries="$(notes_next_count "$NOTES")"
+    if [ "$entries" -lt 0 ]; then
+        refuse "$NOTES has no '$NEXT_HEADING' section." \
+               "Add one above the newest 'Release:' entry, with the same underline."
+    fi
+    if [ "$entries" -eq 0 ]; then
+        refuse "'$NEXT_HEADING' is empty -- there is nothing to say about $new_version." \
+               "Every merged change is supposed to add its own entry.  Add them now," \
+               "then re-run.  Merged since v$base_version:" \
+               "$(merged_since "$remote" "$base_version")"
+    fi
+    ok "$entries entr$([ "$entries" = 1 ] && echo y || echo ies) under $NEXT_HEADING"
+
+    notes_rename_next "$NOTES" "$new_version"
+    ok "$NEXT_HEADING -> Release: $new_version, and a fresh $NEXT_HEADING opened"
+
+    command -v bumpversion >/dev/null 2>&1 || refuse \
+        "bumpversion is not installed." "  pip install -r dev-requirements.txt"
+    # --no-commit --no-tag on purpose: bumpversion's tag would land on this pre-merge
+    # commit, which the merge then rewrites.  `publish` tags the merge commit instead.
+    bumpversion --allow-dirty --no-commit --no-tag "$part"
+
+    # The branch name, the notes heading and the commit subject were all built from
+    # next_version's arithmetic; bumpversion is what actually writes the files. They
+    # agree today for major/minor/patch, but a `parse`/`serialize` added to
+    # .bumpversion.cfg later (pre-release tags, say) would silently make them disagree,
+    # and the release would be named for one version and ship another.
+    local wrote_setup wrote_conf wrote_cfg
+    wrote_setup="$(sed -n "s/^version = '\(.*\)'\$/\1/p" setup.py)"
+    wrote_conf="$(sed -n "s/^version = '\(.*\)'\$/\1/p" docs/conf.py)"
+    wrote_cfg="$(sed -n 's/^current_version = //p' .bumpversion.cfg)"
+    if [ "$wrote_setup" != "$new_version" ] || [ "$wrote_conf" != "$new_version" ] \
+       || [ "$wrote_cfg" != "$new_version" ]; then
+        refuse "bumpversion wrote a different version than this release is named for." \
+               "  expected         $new_version" \
+               "  setup.py         $wrote_setup" \
+               "  docs/conf.py     $wrote_conf" \
+               "  .bumpversion.cfg $wrote_cfg" \
+               "" "Nothing is committed.  Delete the branch and check .bumpversion.cfg:" \
+               "" "  git checkout - && git branch -D $branch"
+    fi
+    ok "version files -> $new_version"
+
+
+    git add -- "$NOTES" setup.py docs/conf.py .bumpversion.cfg
+    git commit --quiet -m "v$base_version -> v$new_version"
+    ok "one commit: v$base_version -> v$new_version"
+
+    git push --quiet "$fork" "$branch"
+    ok "pushed $branch to $fork"
+
+    command -v gh >/dev/null 2>&1 || refuse \
+        "gh is not installed, so the PR was not opened." \
+        "The branch is pushed.  Open it by hand:" "" \
+        "  gh pr create --repo $CANONICAL_SLUG --base master \\" \
+        "    --head $(remote_owner "$fork"):$branch --title 'v$base_version -> v$new_version'"
+
+    local url
+    if ! url="$(gh pr create --repo "$CANONICAL_SLUG" --base master \
+            --head "$(remote_owner "$fork"):$branch" \
+            --title "v$base_version -> v$new_version" \
+            --body "Release $new_version.  Notes: \`$NOTES\`.
+
+Opened by \`tools/release.sh release $part\`.  After merge, the release is
+published by \`./tools/release.sh publish\`, which tags the merge commit." 2>&1)"; then
+        refuse "gh could not open the PR:" "$url" \
+               "The branch is pushed; open the PR by hand."
+    fi
+    ok "PR opened: $url"
+
+    head_ 'Next'
+    printf '  Merge it, then:  ./tools/release.sh publish\n\n'
+}
+
+merged_since() {  # merged_since <remote> <version>
+    local sha; sha="$(remote_tag_sha "$1" "v$2")"
+    if [ -n "$sha" ]; then
+        git log --oneline "$sha..$1/master"
+    else
+        git log --oneline -12 "$1/master"
+    fi
+}
+
+# ---------------------------------------------------------------- publish ----
+
+cmd_publish() {
+    local assume_yes=''
+    [ "${1:-}" = '--yes' ] && assume_yes='1'
+
+    local remote; remote="$(canonical_remote)"
+    head_ 'Publishing'
+    info "canonical remote: $remote ($CANONICAL_SLUG)"
+
+    fetch_master "$remote"
+    local sha short
+    sha="$(git rev-parse "$remote/master")"
+    short="$(git rev-parse --short "$remote/master")"
+    ok "fetched $remote/master ($short)"
+
+    # Everything is read from the remote ref, never from the local checkout.
+    # What gets tagged is what is on the canonical master, regardless of the
+    # state of this clone.
+    local version
+    version="$(require_consistent_versions "$remote/master")"
+    ok "$remote/master is at $version, consistently"
+
+    if ! notes_has_version "$remote/master" "$version"; then
+        refuse "$NOTES on $remote/master has no section for $version." \
+               "The prepare PR is incomplete.  Do not tag it."
+    fi
+    ok "release notes cover $version"
+
+    require_absent_from_pypi "$version"
+    ok "$version is not on PyPI yet"
+
+    local tag="v$version"
+    if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+        local existing; existing="$(git rev-parse "refs/tags/$tag^{commit}")"
+        if [ "$existing" != "$sha" ]; then
+            refuse "Local tag $tag points at $(git rev-parse --short "$existing"), not $short." \
+                   "This is the exact failure that lost v1.2.2 and v1.3.0: a tag left" \
+                   "on a pre-merge commit that never reached $CANONICAL_SLUG." \
+                   "" "  git tag -d $tag" \
+                   "" "then re-run.  The tag belongs on the merge commit."
+        fi
+    fi
+    if git ls-remote --tags --exit-code "$remote" "refs/tags/$tag" >/dev/null 2>&1; then
+        refuse "$remote already has tag $tag but PyPI has no $version." \
+               "The tag build failed or never ran.  Check the build before" \
+               "re-tagging -- deleting and re-pushing a tag is the last resort:" \
+               "" "  https://app.travis-ci.com/github/$CANONICAL_SLUG/builds"
+    fi
+    ok "$tag is free, locally and on $remote"
+
+    head_ 'About to publish'
+    cat <<EOF
+  tag       $tag
+  commit    $short  $(git log -1 --format='%s' "$sha")
+  push to   $remote ($CANONICAL_SLUG)
+
+  Pushing this tag starts a Travis build that uploads $PACKAGE $version to
+  PyPI.  PyPI versions cannot be reused or replaced.
+EOF
+    if [ -z "$assume_yes" ]; then
+        [ -t 0 ] || refuse "Not a terminal; re-run with --yes if this is scripted."
+        printf '\n  Type the version to confirm (%s): ' "$version"
+        local answer; read -r answer
+        [ "$answer" = "$version" ] || refuse 'Not confirmed, nothing pushed.'
+    fi
+
+    git tag -a "$tag" "$sha" -m "$tag"
+    git push "$remote" "refs/tags/$tag"
+    ok "pushed $tag to $remote"
+
+    head_ 'Waiting for PyPI'
+    info "build: https://app.travis-ci.com/github/$CANONICAL_SLUG/builds"
+    local waited=0
+    while [ "$waited" -lt 900 ]; do
+        if [ "$(pypi_state "$version")" = 'published' ]; then
+            ok "$PACKAGE $version is live: https://pypi.org/project/$PACKAGE/$version/"
+            return 0
+        fi
+        sleep 30
+        waited=$((waited + 30))
+        info "still waiting (${waited}s)"
+    done
+
+    refuse "$version has not appeared on PyPI after 15 minutes." \
+           "The tag is pushed, so the release is not lost -- the build is the" \
+           "thing to look at.  A stale or revoked PYPI_TOKEN shows up here:" \
+           "" "  https://app.travis-ci.com/github/$CANONICAL_SLUG/builds"
+}
+
+# ----------------------------------------------------------------- status ----
+
+cmd_status() {
+    local remote; remote="$(canonical_remote)"
+    fetch_master "$remote"
+
+    local version latest
+    version="$(version_from "$remote/master")"
+    latest="$(pypi_latest)"
+
+    head_ 'Status'
+    printf '  %-22s %s\n' 'PyPI latest'          "${latest:-unknown}"
+    printf '  %-22s %s\n' "$remote/master"       "$version ($(git rev-parse --short "$remote/master"))"
+    printf '  %-22s %s\n' 'canonical remote'     "$remote -> $CANONICAL_SLUG"
+
+    local pending; pending="$(git show "$remote/master:$NOTES" 2>/dev/null \
+        | { cat > /tmp/.spektrum_notes.$$; notes_next_count /tmp/.spektrum_notes.$$; \
+            rm -f /tmp/.spektrum_notes.$$; })"
+    if [ "${pending:-0}" -lt 0 ]; then
+        printf '  %-22s %s\n' "$NEXT_HEADING" 'section missing'
+    else
+        printf '  %-22s %s entr%s waiting\n' "$NEXT_HEADING" "$pending" \
+            "$([ "$pending" = 1 ] && echo y || echo ies)"
+    fi
+
+    if [ "$version" != "${latest:-}" ]; then
+        printf '\n  %sUnreleased:%s %s is on master, PyPI has %s\n' \
+            "$C_YELLOW" "$C_OFF" "$version" "${latest:-unknown}"
+        if notes_has_version "$remote/master" "$version"; then
+            printf '  Notes for %s are written -- ready to publish.\n' "$version"
+        else
+            printf '  Notes for %s are NOT written; master is bumped without them.\n' "$version"
+        fi
+    fi
+
+    # Every tag is compared against the canonical repo, not just against local
+    # history.  The two faults look identical in `git tag` output and are not
+    # the same problem: a tag that was never pushed is a lost release, while a
+    # tag that disagrees with the remote is a clone that will mislead whoever
+    # reads it.  This is the check that would have caught v1.2.2 and v1.3.0.
+    head_ 'Tag health'
+    local remote_tags problems=0
+    remote_tags="$(git ls-remote --tags "$remote" 2>/dev/null | awk '
+        {
+            name = $2
+            sub(/^refs\/tags\//, "", name)
+            peeled = sub(/\^\{\}$/, "", name)
+            if (peeled || !(name in seen)) { seen[name] = $1 }
+        }
+        END { for (n in seen) print n, seen[n] }
+    ' | sort -V)"
+
+    local tag local_sha remote_sha
+    while read -r tag; do
+        [ -n "$tag" ] || continue
+        local_sha="$(git rev-parse "refs/tags/$tag^{commit}")"
+        remote_sha="$(printf '%s\n' "$remote_tags" | awk -v t="$tag" '$1 == t {print $2}')"
+
+        if [ -z "$remote_sha" ]; then
+            if git merge-base --is-ancestor "$local_sha" "$remote/master" 2>/dev/null; then
+                printf '  %s%s%s never pushed to %s -- its commit is on master, so the\n' \
+                    "$C_YELLOW" "$tag" "$C_OFF" "$remote"
+                printf '         release was never triggered\n'
+            else
+                printf '  %s%s%s never pushed, and %s is not on master either --\n' \
+                    "$C_RED" "$tag" "$C_OFF" "$(git rev-parse --short "$local_sha")"
+                printf '         this release does not exist anywhere\n'
+            fi
+            problems=$((problems + 1))
+        elif [ "$remote_sha" != "$local_sha" ]; then
+            printf '  %s%s%s disagrees with %s: local %s, remote %s\n' \
+                "$C_YELLOW" "$tag" "$C_OFF" "$remote" \
+                "$(git rev-parse --short "$local_sha")" \
+                "$(git rev-parse --short "$remote_sha" 2>/dev/null || printf '%s' "${remote_sha:0:7}")"
+            problems=$((problems + 1))
+        fi
+    done < <(git tag --list 'v*' | sort -V)
+
+    [ "$problems" -eq 0 ] && ok "all local tags agree with $remote"
+
+    # The range is resolved from the remote's tag, never the local one.  A local
+    # tag of the same name can point somewhere else entirely -- see above.
+    head_ 'Merged since the last published release'
+    local latest_sha=''
+    [ -n "$latest" ] && latest_sha="$(printf '%s\n' "$remote_tags" \
+        | awk -v t="v$latest" '$1 == t {print $2}')"
+
+    if [ -n "$latest_sha" ]; then
+        git log --oneline "$latest_sha..$remote/master" | sed 's/^/  /'
+    else
+        info "$remote has no tag v${latest:-?} to compare against"
+    fi
+    printf '\n'
+}
+
+# ------------------------------------------------------------ interactive ----
+
+# Bare `tools/release.sh`.  Works out which state the repository is in rather than
+# assuming you are at the beginning -- the interesting failures happen when you are not,
+# and "merged but never tagged" is the one that lost v1.2.2 and v1.3.0.
+cmd_interactive() {
+    [ -t 0 ] || refuse "Not a terminal." \
+        "Interactive mode needs a tty.  Use the subcommands when scripting:" \
+        "" "  ./tools/release.sh status | release <part> | publish"
+
+    local remote; remote="$(canonical_remote)"
+    head_ "Spektrum release"
+    info "canonical: $remote ($CANONICAL_SLUG)"
+    fetch_master "$remote"
+
+    local version; version="$(version_from "$remote/master")"
+    [ -n "$version" ] || refuse "Could not read a version from $remote/master:setup.py."
+
+    local state; state="$(pypi_state "$version")"
+    [ "$state" = 'unknown' ] && refuse \
+        "Could not reach PyPI." "Refusing rather than guessing what is published."
+
+    # --- master claims a version PyPI has never seen --------------------------
+    if [ "$state" = 'absent' ]; then
+        if ! notes_has_version "$remote/master" "$version"; then
+            refuse "$remote/master is at $version, which is not on PyPI, but $NOTES" \
+                   "has no section for it.  The version was bumped without notes." \
+                   "Fix that on a branch before releasing anything."
+        fi
+        head_ "$version is merged but was never tagged"
+        cat <<EOF
+  $remote/master  $version ($(git rev-parse --short "$remote/master"))
+  PyPI            $(pypi_latest)
+
+  The release was prepared and merged; the tag that publishes it was never
+  pushed.  This is what happened to 1.2.2 and 1.3.0.
+EOF
+        printf '\n  Tag and publish %s now? [y/N] ' "$version"
+        local go; read -r go
+        case "$go" in
+            [yY]*) printf '\n'; cmd_publish ;;
+            *) printf '\n  Left as is.  When ready:  ./tools/release.sh publish\n\n' ;;
+        esac
+        return
+    fi
+
+    # --- master's version is published; is there anything new? ----------------
+    local base_sha; base_sha="$(remote_tag_sha "$remote" "v$version")"
+    local pending
+    if [ -n "$base_sha" ]; then
+        pending="$(git log --oneline "$base_sha..$remote/master")"
+    else
+        pending="$(git log --oneline -12 "$remote/master")"
+    fi
+
+    if [ -z "$pending" ]; then
+        head_ 'Nothing to release'
+        printf '  %s is the current version and it is published.\n' "$version"
+        printf '  No commits have merged since.  Exiting.\n\n'
+        return
+    fi
+
+    # --- is a release already in flight? --------------------------------------
+    local fork; fork="$(fork_remote "$remote")"
+    local inflight
+    inflight="$(git ls-remote --heads "$fork" "refs/heads/v$version-to-v*" 2>/dev/null \
+        | sed 's#.*refs/heads/##')"
+    if [ -n "$inflight" ]; then
+        head_ 'A release is already open'
+        printf '  Branch %s is pushed to %s.\n' "$inflight" "$fork"
+        printf '  Merge its PR, then re-run this command (or: ./tools/release.sh publish).\n\n'
+        return
+    fi
+
+    head_ "Merged since v$version"
+    printf '%s\n' "$pending" | sed 's/^/  /'
+
+    local entries
+    entries="$(git show "$remote/master:$NOTES" \
+        | { cat > /tmp/.spektrum_notes.$$; notes_next_count /tmp/.spektrum_notes.$$; \
+            rm -f /tmp/.spektrum_notes.$$; })"
+    if [ "$entries" -le 0 ]; then
+        refuse "'$NEXT_HEADING' in $NOTES is empty." \
+               "Those commits merged without saying what changed.  Add an entry for" \
+               "each, in a normal PR, then run this again."
+    fi
+
+    head_ "$NEXT_HEADING"
+    printf '  %s entr%s ready to publish as the next version.\n' \
+        "$entries" "$([ "$entries" = 1 ] && echo y || echo ies)"
+
+    head_ 'Which version?'
+    printf '  current  %s\n' "$version"
+    printf '    patch  %s      minor  %s      major  %s\n\n' \
+        "$(next_version "$version" patch)" \
+        "$(next_version "$version" minor)" \
+        "$(next_version "$version" major)"
+    printf '  major, minor or patch (anything else cancels): '
+    local part; read -r part
+    case "$part" in
+        major|minor|patch) ;;
+        *) printf '\n  Cancelled, nothing changed.\n\n'; return ;;
+    esac
+
+    printf '\n'
+    cmd_release "$part"
+
+    printf '  Has the PR been merged? [y/N] '
+    local merged; read -r merged
+    case "$merged" in
+        [yY]*)
+            printf '\n'
+            # The answer is not trusted: publish re-reads the version, the notes and
+            # the version files from the canonical master and refuses if the bump is
+            # not actually there.  A wrong answer costs a refusal, not a bad tag.
+            cmd_publish
+            ;;
+        *)
+            printf '\n  Fine.  Once it merges:  ./tools/release.sh publish\n\n'
+            ;;
+    esac
+}
+
+# ------------------------------------------------------------------- main ----
+
+case "${1:-}" in
+    ''|-i|--interactive) cmd_interactive ;;
+    status)  shift; cmd_status "$@" ;;
+    release) shift; cmd_release "$@" ;;
+    publish) shift; cmd_publish "$@" ;;
+    prepare)
+        refuse "\`prepare\` was replaced by \`release\`." \
+               "It writes the notes from the accumulated '$NEXT_HEADING' section," \
+               "opens the PR, and leaves tagging to \`publish\`:" \
+               "" "  ./tools/release.sh release <major|minor|patch>"
+        ;;
+    -h|--help|help)
+        cat <<EOF
+Usage: tools/release.sh [command]
+
+  (no arguments)                  interactive: work out what is needed, do it
+  status                          what is released, tagged and drifted
+  release <major|minor|patch>     notes + bump + one commit + PR, for review
+  publish                         tag the merged master and push it (publishes)
+
+Full process: docs/maintenance/index.rst
+EOF
+        ;;
+    *)
+        refuse "Unknown command: $1" "Try:  ./tools/release.sh --help"
+        ;;
+esac


### PR DESCRIPTION
**Issue:** [MQ-3307](https://liquidweb.atlassian.net/browse/MQ-3307)

## Why

Publishing is one act — push a tag to `liquidweb/Spektrum` and Travis uploads to PyPI — and nothing in the repository said so correctly. `docs/maintenance/index.rst`, the only release document, instructed:

```
#. Push up branch and tag
     git push origin prep_for_release --tags
```

Two defects in three lines. `bumpversion` tags the commit it runs on, which on a branch is the pre-merge commit the merge then rewrites; and `origin` is a personal fork for both maintainers, while Travis watches `liquidweb/Spektrum`. Two versions were lost to exactly this — `v1.2.2 → 87916dc` and `v1.3.0 → 3bb7e89`, neither on `master`, neither on any remote. PyPI's latest is 1.2.1, from build #68 on 2025-06-11, the last tag build this repository has had.

From the other end: of the five PRs merged since 1.2.1, **none** touched `docs/release_notes/index.rst`. The log stopped at 1.0.0 while `setup.py` said 1.3.0.

## What

- **`tools/release.sh`** — run bare it is interactive, detecting which of five states the repo is in: nothing merged (exit 0), changes waiting (ask major/minor/patch), `Next Release` empty (refuse), a release PR already open (say what to merge), or **merged but never tagged** (go straight to tagging). `status`, `release <part>` and `publish` remain for when the state is known.
- **A `Next Release` section** in the notes. Every PR adds its own entry as it merges; `release` renames the section to the version it becomes and opens a fresh one. Empty is refused.
- **Release-shaped commit log** — branch `v1.3.1-to-v1.3.2`, subject `v1.3.1 -> v1.3.2`.
- **`.claude/skills/cut-a-release/`** — "let's cut a new release" in a session drives the script. Adds no authority; reimplements no step.
- **Docs** — `docs/maintenance/index.rst` rewritten, `README.rst` gains a Releases section, `AGENTS.md`'s release paragraph corrected (it warned a bump in an ordinary PR "ships a release by accident" — the inverse of the truth).
- **1.3.0 → 1.3.1**, plus the 1.3.1 and 1.3.0 notes entries that were never written.

### Blast radius

**No consumer sees this.** No file under `spektrum/` or `tests/` is touched — the public API, CLI flags and reporters are byte-identical. The only shipped change is the version number and the docs inside the sdist.

### Why one commit with an "and" in the subject

`openspec/project.md` calls that the signal to split. Deliberate here: merging the process alone leaves 1.3.0 unpublished, and merging the bump alone reproduces the state that lost it.

## Reading guide

| File | What to look at | Why |
|---|---|---|
| `tools/release.sh` | `cmd_interactive` (state detection), `cmd_release`, `cmd_publish` | The whole mechanism. Every guard maps to a way a release was lost |
| `docs/maintenance/index.rst` | The five-state table and the by-hand fallback | Replaces instructions that produced dangling tags |
| `docs/release_notes/index.rst` | `Next Release` at the top; 1.3.1 and 1.3.0 entries | 1.3.0 never published, so its notes were reconstructed from `0abb373` |
| `AGENTS.md` | "Versions and releasing" | The corrected claim |
| `.claude/skills/cut-a-release/SKILL.md` | "Your job, and the parts that are not" | Keeps an agent driving the script rather than around it |
| `openspec/changes/` | Two records | `harden-release-process` (this); `enforce-release-notes-and-cadence` (32/50 done, CI gate remaining) |

## Test plan

**Red-then-green:** not applicable — no behavioural change to the library. Both suites are run below as regression proof only.

**Automated tests added/updated:**
- [x] None. The change is shell tooling and documentation; `tests/` covers `spektrum/`, which is untouched. `tools/release.sh` was verified by execution against disposable fixtures — see below.

**Manual verification — six bugs found by running it, zero by reading it.** Everything below ran against bare repositories named to match the canonical slug, with `gh` stubbed to fail and `curl` stubbed where network failure was under test, so nothing could reach GitHub or PyPI.

Found while building:

1. `git fetch --tags` exits non-zero on *"would clobber existing tag"* — the state a failed release leaves a clone in. Under `set -e` it killed the script on its first command, for a condition `status` exists to report. → fetch the branch only.
2. Local branches named `v1.2.0`/`v1.2.1` shadow the tags of the same name, so `rev-parse` resolved the wrong object. → `refs/tags/` throughout; tag ranges resolve from the remote.

Found by deliberately testing paths that had never run:

3. A refusal from `canonical_remote` was **invisible** — it is called as `$(canonical_remote)`, so `refuse` printed into the command substitution and the script exited 1 in silence. → refusals go to stderr.
4. `on_pypi` could not tell 404 from an unreachable PyPI, so with the network down `publish` printed *"✓ 1.3.1 is not on PyPI yet"* and proceeded toward tagging. → `pypi_state` answers published/absent/unknown and **refuses on unknown**. Publishing over an existing version is not recoverable.

Found by testing each of the five interactive states:

5. `release` ran the suites *after* renaming the notes and bumping, so a failing suite left a half-made release — and the re-run refused with *"a release is in progress"*, which was false. → verify before mutating; the branch-exists refusal now distinguishes a leftover with no commit from a real in-flight release.
6. `release` never checked `setup.py`, `docs/conf.py` and `.bumpversion.cfg` agree, so a disagreement surfaced as a raw `bumpversion` traceback, again after the notes were rewritten. → both commands share `require_consistent_versions`, checked before anything is touched.

One guard added with no bug behind it: `next_version` predicts the version and the branch name, notes heading and commit subject are built from that prediction, while `bumpversion` writes the files. They agree today — verified over `1.3.1 → patch → patch → minor → patch → major → minor` against both — but a `parse`/`serialize` added to `.bumpversion.cfg` later would silently diverge and the release would be named for one version and ship another. `release` now compares the written files against the prediction and refuses before committing.

Paths exercised end to end:

| Scenario | Result |
|---|---|
| No remote matching the canonical slug | Refuses, naming the `git remote add` to run |
| Version files disagree | Clean refusal; notes untouched, no branch left behind |
| `Next Release` empty, commits merged | Refuses, listing the commits that said nothing |
| Each of the five interactive states | Correct dispatch |
| Full release, patch | `v1.2.1-to-v1.2.2`, subject `v1.2.1 -> v1.2.2`, 4 files, pushed to fork, **no tag** |
| Full release, minor | `1.2.1 → 1.3.0`, notes renamed, fresh `Next Release` opened |
| Full publish | Annotated tag on the canonical master's **exact SHA**; re-run then refuses |
| `gh` unavailable | Refuses with the exact `gh pr create` to run by hand |
| Version arithmetic | `patch/minor/major` from `1.4.7`, `2.11.9`, `1.9.9`, `9.9.9` — matches `bumpversion` at every step |

Packaging: `python -m build` → `spektrum-1.3.1` sdist + wheel, `twine check` passes.

## Checklist

- [x] `python -m pytest tests -q` — **175 passed**
- [x] `python -m spektrum -s tests/live/` — **22 passed, 121 expectations, exit 0**
- [x] `tox -e flake8` clean (`python -m flake8 spektrum tests`, exit 0). Also `shellcheck -S style tools/release.sh` — **0 findings**
- [x] Docs updated — `README.rst`, `AGENTS.md`, `docs/maintenance/index.rst`, `docs/release_notes/index.rst`
- [x] Squashed to a single commit
- [x] **Version bump included, because this PR is the release** — 1.3.0 → 1.3.1
- [x] No secrets, tokens, or real customer data

`openspec validate --all` — 10 passed, 0 failed.

> **Note for the reviewer:** the live suite prints 13 nested sub-run summaries, some showing failures, from the fixture specs it drives. That output is byte-identical on a worktree cut from `b7c2850`, so it is pre-existing and not a regression. It is genuinely misleading to read and deserves its own change.

## After merge

`./tools/release.sh` detects merged-but-never-tagged and offers to publish 1.3.1. `PYPI_TOKEN` has not been exercised since 2025-06-11, so if the deploy fails on auth it is a Travis repository secret a repo admin can rotate.


[MQ-3307]: https://liquidweb.atlassian.net/browse/MQ-3307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ